### PR TITLE
Add magic bitboard slider move generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,15 +12,22 @@ src/MoveGenerator.cpp
 src/PrintMoves.cpp)
 
 add_executable(KnightMoveTests
-src/KnightMoveTests.cpp
-src/Board.cpp
-src/MoveGenerator.cpp
-src/PrintMoves.cpp)
+    src/KnightMoveTests.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp)
+
+add_executable(SliderMoveTests
+    src/SliderMoveTests.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp)
 
 # Include directories
 target_include_directories(ChessAI PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PawnMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KnightMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 
 

--- a/src/Board.h
+++ b/src/Board.h
@@ -20,6 +20,12 @@ public:
 
     uint64_t getWhiteKnights() const { return whiteKnights; }
     uint64_t getBlackKnights() const { return blackKnights; }
+    uint64_t getWhiteRooks()   const { return whiteRooks;   }
+    uint64_t getBlackRooks()   const { return blackRooks;   }
+    uint64_t getWhiteBishops() const { return whiteBishops; }
+    uint64_t getBlackBishops() const { return blackBishops; }
+    uint64_t getWhiteQueens()  const { return whiteQueens;  }
+    uint64_t getBlackQueens()  const { return blackQueens;  }
 
     // Setters for testing
     void setWhitePawns(uint64_t value) { whitePawns = value; }
@@ -27,6 +33,10 @@ public:
     void setWhiteKing(uint64_t value) { whiteKing = value; }
     void setBlackKing(uint64_t value) { blackKing = value; }
     void setWhiteRooks(uint64_t value) { whiteRooks = value; }
+    void setBlackRooks(uint64_t value) { blackRooks = value; }
+    void setWhiteBishops(uint64_t value) { whiteBishops = value; }
+    void setBlackBishops(uint64_t value) { blackBishops = value; }
+    void setWhiteQueens(uint64_t value) { whiteQueens = value; }
     void setBlackQueens(uint64_t value) { blackQueens = value; }
     void setWhiteKnights(uint64_t value) { whiteKnights = value; }
     void setBlackKnights(uint64_t value) { blackKnights = value; }

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -8,6 +8,8 @@
 #endif
 #include <iostream>  // For printing moves
 #include <string>
+#include <random>
+#include <array>
 
 // Cross-platform bit scan (find least significant bit index)
 inline int popLSBIndex(uint64_t& bitboard) {
@@ -21,6 +23,189 @@ inline int popLSBIndex(uint64_t& bitboard) {
     bitboard &= bitboard - 1;
     return index;
 #endif
+}
+
+namespace Magic {
+    using U64 = uint64_t;
+
+    std::array<U64, 64> rookMasks{};
+    std::array<U64, 64> bishopMasks{};
+    std::array<U64, 64> rookMagics{};
+    std::array<U64, 64> bishopMagics{};
+    std::array<int, 64> rookShifts{};
+    std::array<int, 64> bishopShifts{};
+    std::array<std::vector<U64>, 64> rookTable{};
+    std::array<std::vector<U64>, 64> bishopTable{};
+    bool initialized = false;
+
+    inline int popcount(U64 b) {
+#if defined(_MSC_VER)
+        return static_cast<int>(__popcnt64(b));
+#else
+        return __builtin_popcountll(b);
+#endif
+    }
+
+    U64 random_u64() {
+        static std::mt19937_64 gen(42);
+        std::uniform_int_distribution<U64> dist(0, ~0ULL);
+        return dist(gen);
+    }
+
+    U64 maskRook(int sq) {
+        U64 mask = 0ULL;
+        int r = sq / 8, f = sq % 8;
+        for (int r1 = r + 1; r1 <= 6; ++r1) mask |= 1ULL << (r1 * 8 + f);
+        for (int r1 = r - 1; r1 >= 1; --r1) mask |= 1ULL << (r1 * 8 + f);
+        for (int f1 = f + 1; f1 <= 6; ++f1) mask |= 1ULL << (r * 8 + f1);
+        for (int f1 = f - 1; f1 >= 1; --f1) mask |= 1ULL << (r * 8 + f1);
+        return mask;
+    }
+
+    U64 maskBishop(int sq) {
+        U64 mask = 0ULL;
+        int r = sq / 8, f = sq % 8;
+        for (int r1 = r + 1, f1 = f + 1; r1 <= 6 && f1 <= 6; ++r1, ++f1)
+            mask |= 1ULL << (r1 * 8 + f1);
+        for (int r1 = r + 1, f1 = f - 1; r1 <= 6 && f1 >= 1; ++r1, --f1)
+            mask |= 1ULL << (r1 * 8 + f1);
+        for (int r1 = r - 1, f1 = f + 1; r1 >= 1 && f1 <= 6; --r1, ++f1)
+            mask |= 1ULL << (r1 * 8 + f1);
+        for (int r1 = r - 1, f1 = f - 1; r1 >= 1 && f1 >= 1; --r1, --f1)
+            mask |= 1ULL << (r1 * 8 + f1);
+        return mask;
+    }
+
+    U64 rookAttacksOnTheFly(int sq, U64 occ) {
+        U64 attacks = 0ULL;
+        int r = sq / 8, f = sq % 8;
+        for (int r1 = r + 1; r1 <= 7; ++r1) {
+            int s = r1 * 8 + f; attacks |= 1ULL << s; if (occ & (1ULL << s)) break;
+        }
+        for (int r1 = r - 1; r1 >= 0; --r1) {
+            int s = r1 * 8 + f; attacks |= 1ULL << s; if (occ & (1ULL << s)) break;
+        }
+        for (int f1 = f + 1; f1 <= 7; ++f1) {
+            int s = r * 8 + f1; attacks |= 1ULL << s; if (occ & (1ULL << s)) break;
+        }
+        for (int f1 = f - 1; f1 >= 0; --f1) {
+            int s = r * 8 + f1; attacks |= 1ULL << s; if (occ & (1ULL << s)) break;
+        }
+        return attacks;
+    }
+
+    U64 bishopAttacksOnTheFly(int sq, U64 occ) {
+        U64 attacks = 0ULL;
+        int r = sq / 8, f = sq % 8;
+        for (int r1 = r + 1, f1 = f + 1; r1 <= 7 && f1 <= 7; ++r1, ++f1) {
+            int s = r1 * 8 + f1; attacks |= 1ULL << s; if (occ & (1ULL << s)) break;
+        }
+        for (int r1 = r + 1, f1 = f - 1; r1 <= 7 && f1 >= 0; ++r1, --f1) {
+            int s = r1 * 8 + f1; attacks |= 1ULL << s; if (occ & (1ULL << s)) break;
+        }
+        for (int r1 = r - 1, f1 = f + 1; r1 >= 0 && f1 <= 7; --r1, ++f1) {
+            int s = r1 * 8 + f1; attacks |= 1ULL << s; if (occ & (1ULL << s)) break;
+        }
+        for (int r1 = r - 1, f1 = f - 1; r1 >= 0 && f1 >= 0; --r1, --f1) {
+            int s = r1 * 8 + f1; attacks |= 1ULL << s; if (occ & (1ULL << s)) break;
+        }
+        return attacks;
+    }
+
+    U64 setOccupancy(int index, int bits, const std::vector<int>& squares) {
+        U64 occ = 0ULL;
+        for (int i = 0; i < bits; ++i)
+            if (index & (1 << i))
+                occ |= 1ULL << squares[i];
+        return occ;
+    }
+
+    U64 findMagic(int sq, int bits, bool bishop) {
+        std::vector<int> squares;
+        U64 mask = bishop ? maskBishop(sq) : maskRook(sq);
+        for (U64 m = mask; m; m &= m - 1)
+            squares.push_back(popLSBIndex(m));
+
+        int size = 1 << bits;
+        std::vector<U64> occupancies(size), attacks(size);
+        for (int i = 0; i < size; ++i) {
+            occupancies[i] = setOccupancy(i, bits, squares);
+            attacks[i] = bishop ? bishopAttacksOnTheFly(sq, occupancies[i])
+                               : rookAttacksOnTheFly(sq, occupancies[i]);
+        }
+
+        while (true) {
+            U64 magic = random_u64() & random_u64() & random_u64();
+
+            if (popcount((mask * magic) & 0xFF00000000000000ULL) < 6) continue;
+
+            std::vector<U64> used(size, 0ULL);
+            bool fail = false;
+
+            for (int i = 0; i < size && !fail; ++i) {
+                int index = (int)((occupancies[i] * magic) >> (64 - bits));
+                if (!used[index])
+                    used[index] = attacks[i];
+                else if (used[index] != attacks[i])
+                    fail = true;
+            }
+            if (!fail)
+                return magic;
+        }
+    }
+
+    void init() {
+        if (initialized) return;
+        for (int sq = 0; sq < 64; ++sq) {
+            rookMasks[sq] = maskRook(sq);
+            bishopMasks[sq] = maskBishop(sq);
+
+            int rBits = popcount(rookMasks[sq]);
+            int bBits = popcount(bishopMasks[sq]);
+            rookShifts[sq] = 64 - rBits;
+            bishopShifts[sq] = 64 - bBits;
+
+            rookTable[sq].resize(1ULL << rBits);
+            bishopTable[sq].resize(1ULL << bBits);
+
+            rookMagics[sq] = findMagic(sq, rBits, false);
+            bishopMagics[sq] = findMagic(sq, bBits, true);
+        }
+
+        // Precompute attack tables
+        for (int sq = 0; sq < 64; ++sq) {
+            int rBits = popcount(rookMasks[sq]);
+            int bBits = popcount(bishopMasks[sq]);
+            std::vector<int> rSquares, bSquares;
+            for (U64 m = rookMasks[sq]; m; m &= m - 1) rSquares.push_back(popLSBIndex(m));
+            for (U64 m = bishopMasks[sq]; m; m &= m - 1) bSquares.push_back(popLSBIndex(m));
+
+            for (int i = 0; i < (1 << rBits); ++i) {
+                U64 occ = setOccupancy(i, rBits, rSquares);
+                int index = (int)((occ * rookMagics[sq]) >> (64 - rBits));
+                rookTable[sq][index] = rookAttacksOnTheFly(sq, occ);
+            }
+            for (int i = 0; i < (1 << bBits); ++i) {
+                U64 occ = setOccupancy(i, bBits, bSquares);
+                int index = (int)((occ * bishopMagics[sq]) >> (64 - bBits));
+                bishopTable[sq][index] = bishopAttacksOnTheFly(sq, occ);
+            }
+        }
+
+        initialized = true;
+    }
+
+    U64 getRookAttacks(int sq, U64 occ) {
+        U64 masked = occ & rookMasks[sq];
+        int index = (int)((masked * rookMagics[sq]) >> rookShifts[sq]);
+        return rookTable[sq][index];
+    }
+
+    U64 getBishopAttacks(int sq, U64 occ) {
+        U64 masked = occ & bishopMasks[sq];
+        int index = (int)((masked * bishopMagics[sq]) >> bishopShifts[sq]);
+        return bishopTable[sq][index];
+    }
 }
 
 // Converts square index (0-63) to chess notation (e.g., 8 -> "e2")
@@ -177,6 +362,57 @@ std::vector<std::string> MoveGenerator::generateKnightMoves(const Board& board, 
         }
     }
 
+    return moves;
+}
+
+std::vector<std::string> MoveGenerator::generateRookMoves(const Board& board, bool isWhite) {
+    Magic::init();
+    std::vector<std::string> moves;
+    uint64_t rooks = isWhite ? board.getWhiteRooks() : board.getBlackRooks();
+    uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
+    uint64_t occupancy = board.getWhitePieces() | board.getBlackPieces();
+    while (rooks) {
+        int from = popLSBIndex(rooks);
+        uint64_t attacks = Magic::getRookAttacks(from, occupancy) & ~ownPieces;
+        for (uint64_t m = attacks; m; m &= m - 1) {
+            int to = __builtin_ctzll(m);
+            moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        }
+    }
+    return moves;
+}
+
+std::vector<std::string> MoveGenerator::generateBishopMoves(const Board& board, bool isWhite) {
+    Magic::init();
+    std::vector<std::string> moves;
+    uint64_t bishops = isWhite ? board.getWhiteBishops() : board.getBlackBishops();
+    uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
+    uint64_t occupancy = board.getWhitePieces() | board.getBlackPieces();
+    while (bishops) {
+        int from = popLSBIndex(bishops);
+        uint64_t attacks = Magic::getBishopAttacks(from, occupancy) & ~ownPieces;
+        for (uint64_t m = attacks; m; m &= m - 1) {
+            int to = __builtin_ctzll(m);
+            moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        }
+    }
+    return moves;
+}
+
+std::vector<std::string> MoveGenerator::generateQueenMoves(const Board& board, bool isWhite) {
+    Magic::init();
+    std::vector<std::string> moves;
+    uint64_t queens = isWhite ? board.getWhiteQueens() : board.getBlackQueens();
+    uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
+    uint64_t occupancy = board.getWhitePieces() | board.getBlackPieces();
+    while (queens) {
+        int from = popLSBIndex(queens);
+        uint64_t attacks = (Magic::getRookAttacks(from, occupancy) | Magic::getBishopAttacks(from, occupancy)) & ~ownPieces;
+        for (uint64_t m = attacks; m; m &= m - 1) {
+            int to = __builtin_ctzll(m);
+            moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        }
+    }
     return moves;
 }
 

--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -11,6 +11,9 @@ class MoveGenerator {
 public:
     std::vector<std::string> generatePawnMoves(const Board& board, bool isWhite);
     std::vector<std::string> generateKnightMoves(const Board& board, bool isWhite);
+    std::vector<std::string> generateRookMoves(const Board& board, bool isWhite);
+    std::vector<std::string> generateBishopMoves(const Board& board, bool isWhite);
+    std::vector<std::string> generateQueenMoves(const Board& board, bool isWhite);
     void addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift);
 };
 

--- a/src/SliderMoveTests.cpp
+++ b/src/SliderMoveTests.cpp
@@ -1,0 +1,49 @@
+#include "Board.h"
+#include "MoveGenerator.h"
+#include "PrintMoves.h"
+#include <cassert>
+#include <iostream>
+
+void testRookMoves() {
+    Board board;
+    board.clearBoard();
+    board.setWhiteRooks(1ULL << 27); // d4
+
+    MoveGenerator gen;
+    auto moves = gen.generateRookMoves(board, true);
+    std::cout << "\n[?] Rook Moves\n";
+    printMoves(moves);
+    assert(moves.size() == 14);
+}
+
+void testBishopMoves() {
+    Board board;
+    board.clearBoard();
+    board.setWhiteBishops(1ULL << 27); // d4
+
+    MoveGenerator gen;
+    auto moves = gen.generateBishopMoves(board, true);
+    std::cout << "\n[?] Bishop Moves\n";
+    printMoves(moves);
+    assert(moves.size() == 13);
+}
+
+void testQueenMoves() {
+    Board board;
+    board.clearBoard();
+    board.setWhiteQueens(1ULL << 27); // d4
+
+    MoveGenerator gen;
+    auto moves = gen.generateQueenMoves(board, true);
+    std::cout << "\n[?] Queen Moves\n";
+    printMoves(moves);
+    assert(moves.size() == 27);
+}
+
+int main() {
+    testRookMoves();
+    testBishopMoves();
+    testQueenMoves();
+    std::cout << "\nAll slider move tests passed!\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement magic bitboard infrastructure and slider move generation
- expose getters/setters for all piece bitboards
- add tests verifying rook/bishop/queen moves

## Testing
- `cmake ..`
- `cmake --build .`
- `./BoardTest`
- `./PawnMoveTests`
- `./KnightMoveTests`
- `./SliderMoveTests`


------
https://chatgpt.com/codex/tasks/task_e_688593d7114c832e92a18efdfd05a5d3