### PR TITLE
Add king move generation and FEN parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,18 @@ add_executable(SliderMoveTests
     src/MoveGenerator.cpp
     src/PrintMoves.cpp)
 
+add_executable(KingMoveTests
+    src/KingMoveTests.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp)
+
 # Include directories
 target_include_directories(ChessAI PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PawnMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KnightMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 
 

--- a/src/Board.h
+++ b/src/Board.h
@@ -1,15 +1,29 @@
 #pragma once
 #include <cstdint>
+#include <string>
 
 class Board {
 private:
     uint64_t whitePawns, whiteKnights, whiteBishops, whiteRooks, whiteQueens, whiteKing;
     uint64_t blackPawns, blackKnights, blackBishops, blackRooks, blackQueens, blackKing;
     int enPassantSquare;
+    bool whiteToMove;
+    bool castleWK, castleWQ, castleBK, castleBQ;
 
 
 public:
     Board();
+
+    bool isWhiteToMove() const { return whiteToMove; }
+    bool canCastleWK() const { return castleWK; }
+    bool canCastleWQ() const { return castleWQ; }
+    bool canCastleBK() const { return castleBK; }
+    bool canCastleBQ() const { return castleBQ; }
+    void setWhiteToMove(bool v) { whiteToMove = v; }
+    void setCastleWK(bool v) { castleWK = v; }
+    void setCastleWQ(bool v) { castleWQ = v; }
+    void setCastleBK(bool v) { castleBK = v; }
+    void setCastleBQ(bool v) { castleBQ = v; }
 
     // Getters for testing and internal logic
     uint64_t getWhitePawns() const { return whitePawns; }
@@ -26,6 +40,8 @@ public:
     uint64_t getBlackBishops() const { return blackBishops; }
     uint64_t getWhiteQueens()  const { return whiteQueens;  }
     uint64_t getBlackQueens()  const { return blackQueens;  }
+    uint64_t getWhiteKing() const { return whiteKing; }
+    uint64_t getBlackKing() const { return blackKing; }
 
     // Setters for testing
     void setWhitePawns(uint64_t value) { whitePawns = value; }
@@ -44,4 +60,5 @@ public:
 
     void clearBoard();  // Utility function to reset the board state
     void printBoard() const;
+    bool loadFEN(const std::string& fen);
 };

--- a/src/KingMoveTests.cpp
+++ b/src/KingMoveTests.cpp
@@ -1,0 +1,45 @@
+#include "Board.h"
+#include "MoveGenerator.h"
+#include "PrintMoves.h"
+#include <cassert>
+#include <iostream>
+
+void testBasicKingMoves() {
+    Board b;
+    b.loadFEN("8/8/8/3K4/8/8/8/8 w - - 0 1");
+    MoveGenerator g;
+    auto moves = g.generateKingMoves(b, true);
+    std::cout << "\n[?] King Moves from d5" << std::endl;
+    printMoves(moves);
+    assert(moves.size() == 8);
+}
+
+void testCastling() {
+    Board b;
+    b.loadFEN("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    MoveGenerator g;
+    auto wmoves = g.generateKingMoves(b, true);
+    std::cout << "\n[?] White Castling" << std::endl;
+    printMoves(wmoves);
+    bool hasK = false, hasQ = false;
+    for (auto &m : wmoves) {
+        if (m.find("Castle Kingside") != std::string::npos) hasK = true;
+        if (m.find("Castle Queenside") != std::string::npos) hasQ = true;
+    }
+    assert(hasK && hasQ);
+
+    auto bmoves = g.generateKingMoves(b, false);
+    bool bK = false, bQ = false;
+    for (auto &m : bmoves) {
+        if (m.find("Castle Kingside") != std::string::npos) bK = true;
+        if (m.find("Castle Queenside") != std::string::npos) bQ = true;
+    }
+    assert(bK && bQ);
+}
+
+int main() {
+    testBasicKingMoves();
+    testCastling();
+    std::cout << "\nAll king move tests passed!" << std::endl;
+    return 0;
+}

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -416,4 +416,52 @@ std::vector<std::string> MoveGenerator::generateQueenMoves(const Board& board, b
     return moves;
 }
 
+std::vector<std::string> MoveGenerator::generateKingMoves(const Board& board, bool isWhite) {
+    std::vector<std::string> moves;
+    uint64_t king = isWhite ? board.getWhiteKing() : board.getBlackKing();
+    if (!king) return moves;
+    uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
+
+    int from = __builtin_ctzll(king);
+    int fx = from % 8; int fy = from / 8;
+    for (int dy = -1; dy <= 1; ++dy) {
+        for (int dx = -1; dx <= 1; ++dx) {
+            if (dx == 0 && dy == 0) continue;
+            int tx = fx + dx; int ty = fy + dy;
+            if (tx < 0 || tx > 7 || ty < 0 || ty > 7) continue;
+            int to = ty * 8 + tx;
+            uint64_t mask = 1ULL << to;
+            if (mask & ownPieces) continue;
+            moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        }
+    }
+
+    uint64_t allPieces = board.getWhitePieces() | board.getBlackPieces();
+    if (isWhite) {
+        if (board.canCastleWK() && (from == 4) &&
+            !(allPieces & ((1ULL<<5) | (1ULL<<6))) &&
+            (board.getWhiteRooks() & (1ULL<<7))) {
+            moves.push_back("e1-g1 (Castle Kingside)");
+        }
+        if (board.canCastleWQ() && (from == 4) &&
+            !(allPieces & ((1ULL<<1)|(1ULL<<2)|(1ULL<<3))) &&
+            (board.getWhiteRooks() & (1ULL<<0))) {
+            moves.push_back("e1-c1 (Castle Queenside)");
+        }
+    } else {
+        if (board.canCastleBK() && (from == 60) &&
+            !(allPieces & ((1ULL<<61) | (1ULL<<62))) &&
+            (board.getBlackRooks() & (1ULL<<63))) {
+            moves.push_back("e8-g8 (Castle Kingside)");
+        }
+        if (board.canCastleBQ() && (from == 60) &&
+            !(allPieces & ((1ULL<<57)|(1ULL<<58)|(1ULL<<59))) &&
+            (board.getBlackRooks() & (1ULL<<56))) {
+            moves.push_back("e8-c8 (Castle Queenside)");
+        }
+    }
+
+    return moves;
+}
+
 

--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -14,6 +14,7 @@ public:
     std::vector<std::string> generateRookMoves(const Board& board, bool isWhite);
     std::vector<std::string> generateBishopMoves(const Board& board, bool isWhite);
     std::vector<std::string> generateQueenMoves(const Board& board, bool isWhite);
+    std::vector<std::string> generateKingMoves(const Board& board, bool isWhite);
     void addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift);
 };
 


### PR DESCRIPTION
## Summary
- implement FEN loading in `Board` and use it for default setup
- store side to move and castling rights
- implement king move generation with basic castling logic
- add tests for king moves
- compile new test target in CMake

## Testing
- `cmake ..`
- `make ChessAI BoardTest PawnMoveTests KnightMoveTests SliderMoveTests KingMoveTests`
- `./BoardTest`
- `./PawnMoveTests`
- `./KnightMoveTests`
- `./SliderMoveTests`
- `./KingMoveTests`


------
https://chatgpt.com/codex/tasks/task_e_688596ae83f0832ea0f2ff35073ce12c