### PR TITLE
Implement simple chess engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,31 +3,33 @@ project(ChessAI)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_executable(ChessAI src/main.cpp src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp )
-add_executable(BoardTest src/BoardTest.cpp src/Board.cpp  src/PrintMoves.cpp src/MoveGenerator.cpp)
+set(ENGINE_SOURCES src/Engine.cpp)
+
+add_executable(ChessAI src/main.cpp src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
+add_executable(BoardTest src/BoardTest.cpp src/Board.cpp  src/PrintMoves.cpp src/MoveGenerator.cpp ${ENGINE_SOURCES})
 add_executable(PawnMoveTests
 src/PawnMoveTests.cpp
 src/Board.cpp
 src/MoveGenerator.cpp
-src/PrintMoves.cpp)
+src/PrintMoves.cpp ${ENGINE_SOURCES})
 
 add_executable(KnightMoveTests
     src/KnightMoveTests.cpp
     src/Board.cpp
     src/MoveGenerator.cpp
-    src/PrintMoves.cpp)
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
 
 add_executable(SliderMoveTests
     src/SliderMoveTests.cpp
     src/Board.cpp
     src/MoveGenerator.cpp
-    src/PrintMoves.cpp)
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
 
 add_executable(KingMoveTests
     src/KingMoveTests.cpp
     src/Board.cpp
     src/MoveGenerator.cpp
-    src/PrintMoves.cpp)
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
 
 # Include directories
 target_include_directories(ChessAI PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -95,3 +95,37 @@ bool Board::loadFEN(const std::string& fen) {
 
     return true;
 }
+
+int algebraicToIndex(const std::string& sq) {
+    if (sq.size() < 2) return -1;
+    int file = sq[0] - 'a';
+    int rank = sq[1] - '1';
+    return rank * 8 + file;
+}
+
+void Board::makeMove(const std::string& move) {
+    auto dash = move.find('-');
+    if (dash == std::string::npos) return;
+    int from = algebraicToIndex(move.substr(0, 2));
+    int to = algebraicToIndex(move.substr(dash + 1, 2));
+    if (from < 0 || to < 0) return;
+    uint64_t fromMask = 1ULL << from;
+    uint64_t toMask = 1ULL << to;
+
+    auto movePiece = [&](uint64_t &bb) {
+        if (bb & fromMask) { bb &= ~fromMask; bb &= ~toMask; bb |= toMask; return true; } return false; };
+
+    if (!(movePiece(whitePawns) || movePiece(whiteKnights) || movePiece(whiteBishops) ||
+          movePiece(whiteRooks) || movePiece(whiteQueens) || movePiece(whiteKing) ||
+          movePiece(blackPawns) || movePiece(blackKnights) || movePiece(blackBishops) ||
+          movePiece(blackRooks) || movePiece(blackQueens) || movePiece(blackKing))) {
+        return;
+    }
+
+    // Remove captured piece
+    uint64_t mask = ~toMask;
+    whitePawns &= mask; whiteKnights &= mask; whiteBishops &= mask; whiteRooks &= mask; whiteQueens &= mask; whiteKing &= mask;
+    blackPawns &= mask; blackKnights &= mask; blackBishops &= mask; blackRooks &= mask; blackQueens &= mask; blackKing &= mask;
+
+    whiteToMove = !whiteToMove;
+}

--- a/src/Board.h
+++ b/src/Board.h
@@ -61,4 +61,7 @@ public:
     void clearBoard();  // Utility function to reset the board state
     void printBoard() const;
     bool loadFEN(const std::string& fen);
+    void makeMove(const std::string& move);
 };
+
+int algebraicToIndex(const std::string& sq);

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1,0 +1,74 @@
+#include "Engine.h"
+#include <algorithm>
+
+static int popcount(uint64_t x) {
+#if defined(_MSC_VER)
+    return static_cast<int>(__popcnt64(x));
+#else
+    return __builtin_popcountll(x);
+#endif
+}
+
+int Engine::evaluate(const Board& b) const {
+    const int pawn = 100, knight = 320, bishop = 330, rook = 500, queen = 900, king = 20000;
+    int score = 0;
+    score += popcount(b.getWhitePawns()) * pawn;
+    score -= popcount(b.getBlackPawns()) * pawn;
+    score += popcount(b.getWhiteKnights()) * knight;
+    score -= popcount(b.getBlackKnights()) * knight;
+    score += popcount(b.getWhiteBishops()) * bishop;
+    score -= popcount(b.getBlackBishops()) * bishop;
+    score += popcount(b.getWhiteRooks()) * rook;
+    score -= popcount(b.getBlackRooks()) * rook;
+    score += popcount(b.getWhiteQueens()) * queen;
+    score -= popcount(b.getBlackQueens()) * queen;
+    score += popcount(b.getWhiteKing()) * king;
+    score -= popcount(b.getBlackKing()) * king;
+    return score;
+}
+
+int Engine::minimax(Board& board, int depth, int alpha, int beta, bool maximizing) {
+    if (depth == 0) return evaluate(board);
+    auto moves = generator.generateAllMoves(board, board.isWhiteToMove());
+    if (moves.empty()) return evaluate(board);
+    if (maximizing) {
+        int maxEval = -1000000;
+        for (const auto& m : moves) {
+            Board copy = board;
+            copy.makeMove(m);
+            int eval = minimax(copy, depth - 1, alpha, beta, false);
+            maxEval = std::max(maxEval, eval);
+            alpha = std::max(alpha, eval);
+            if (beta <= alpha) break;
+        }
+        return maxEval;
+    } else {
+        int minEval = 1000000;
+        for (const auto& m : moves) {
+            Board copy = board;
+            copy.makeMove(m);
+            int eval = minimax(copy, depth - 1, alpha, beta, true);
+            minEval = std::min(minEval, eval);
+            beta = std::min(beta, eval);
+            if (beta <= alpha) break;
+        }
+        return minEval;
+    }
+}
+
+std::string Engine::searchBestMove(Board& board, int depth) {
+    auto moves = generator.generateAllMoves(board, board.isWhiteToMove());
+    std::string bestMove;
+    int bestScore = board.isWhiteToMove() ? -1000000 : 1000000;
+    for (const auto& m : moves) {
+        Board copy = board;
+        copy.makeMove(m);
+        int score = minimax(copy, depth - 1, -1000000, 1000000, !board.isWhiteToMove());
+        if (board.isWhiteToMove()) {
+            if (score > bestScore) { bestScore = score; bestMove = m; }
+        } else {
+            if (score < bestScore) { bestScore = score; bestMove = m; }
+        }
+    }
+    return bestMove;
+}

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Board.h"
+#include "MoveGenerator.h"
+#include <string>
+
+class Engine {
+public:
+    int evaluate(const Board& board) const;
+    int minimax(Board& board, int depth, int alpha, int beta, bool maximizing);
+    std::string searchBestMove(Board& board, int depth);
+private:
+    MoveGenerator generator;
+};

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -464,4 +464,18 @@ std::vector<std::string> MoveGenerator::generateKingMoves(const Board& board, bo
     return moves;
 }
 
+std::vector<std::string> MoveGenerator::generateAllMoves(const Board& board, bool isWhite) {
+    std::vector<std::string> all;
+    auto append = [&all](const std::vector<std::string>& mv) {
+        all.insert(all.end(), mv.begin(), mv.end());
+    };
+    append(generatePawnMoves(board, isWhite));
+    append(generateKnightMoves(board, isWhite));
+    append(generateBishopMoves(board, isWhite));
+    append(generateRookMoves(board, isWhite));
+    append(generateQueenMoves(board, isWhite));
+    append(generateKingMoves(board, isWhite));
+    return all;
+}
+
 

--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -15,6 +15,7 @@ public:
     std::vector<std::string> generateBishopMoves(const Board& board, bool isWhite);
     std::vector<std::string> generateQueenMoves(const Board& board, bool isWhite);
     std::vector<std::string> generateKingMoves(const Board& board, bool isWhite);
+    std::vector<std::string> generateAllMoves(const Board& board, bool isWhite);
     void addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift);
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,15 +1,11 @@
 #include <iostream>
 #include "Board.h"
-#include "MoveGenerator.h"
-#include "PrintMoves.h"
+#include "Engine.h"
 
 int main() {
     Board board;
-    MoveGenerator moveGenerator;
-
-    std::vector<std::string> moves = moveGenerator.generatePawnMoves(board, true); // Updated to std::string
-    std::cout << "Pawn Moves (Algebraic Notation):\n";
-    printMoves(moves);  // Updated to call the new print function for strings
-
+    Engine engine;
+    std::string best = engine.searchBestMove(board, 2);
+    std::cout << "Best move from starting position: " << best << "\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- add a new Engine module with board evaluation and a minimax search
- support simple move making on the Board
- extend the move generator with an `generateAllMoves` helper
- update main program to search for a move
- build Engine into all targets via CMake

## Testing
- `cmake ..`
- `make -j`
- `./BoardTest`
- `./PawnMoveTests`
- `./KnightMoveTests`
- `./SliderMoveTests`
- `./KingMoveTests`
- `./ChessAI`

------
https://chatgpt.com/codex/tasks/task_e_688598e5a110832ea2baf544520b401a