### PR TITLE
Add CTest support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(ChessAI)
 
+include(CTest)
+enable_testing()
+
 set(CMAKE_CXX_STANDARD 17)
 
 set(ENGINE_SOURCES src/Engine.cpp)
@@ -33,10 +36,18 @@ add_executable(KingMoveTests
 
 # Include directories
 target_include_directories(ChessAI PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(BoardTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PawnMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KnightMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+# Register tests with CTest
+add_test(NAME BoardTest COMMAND BoardTest)
+add_test(NAME PawnMoveTests COMMAND PawnMoveTests)
+add_test(NAME KnightMoveTests COMMAND KnightMoveTests)
+add_test(NAME SliderMoveTests COMMAND SliderMoveTests)
+add_test(NAME KingMoveTests COMMAND KingMoveTests)
 
 
 

--- a/README.md
+++ b/README.md
@@ -27,18 +27,16 @@ It will generate pawn moves for the initial board and print them.
 
 ## Running the Tests
 
-The build produces a test executable for each source file ending with `*Tests.cpp` and a `BoardTest`.
-Run them individually inside the `build` directory:
+Tests are registered with **CTest**, so once the project is built they can be
+executed all together:
 
 ```bash
-./BoardTest
-./PawnMoveTests
-./KnightMoveTests
-./SliderMoveTests
-./KingMoveTests
+ctest
 ```
 
-Each test binary prints diagnostic information and ends with a success message when all assertions pass.
+You can still run individual binaries (e.g. `./PawnMoveTests`) from the `build`
+directory if needed. Each test binary prints diagnostic information and exits
+with success when all assertions pass.
 
 ## Code Structure
 


### PR DESCRIPTION
## Summary
- enable testing and register existing test programs with CTest
- document test execution using `ctest`

## Testing
- `cmake .. && make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68859a1c2d38832eaba6e78cd88a9f16