### PR TITLE
Add usage examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,14 @@ add_executable(KingMoveTests
     src/MoveGenerator.cpp
     src/PrintMoves.cpp ${ENGINE_SOURCES})
 
+# Example programs
+add_executable(CreatePosition examples/create_position.cpp
+    src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
+add_executable(GenerateMoves examples/generate_moves.cpp
+    src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
+add_executable(SearchBestMove examples/search_best_move.cpp
+    src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 # Include directories
 target_include_directories(ChessAI PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(BoardTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -41,6 +49,9 @@ target_include_directories(PawnMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KnightMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(CreatePosition PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 # Register tests with CTest
 add_test(NAME BoardTest COMMAND BoardTest)

--- a/README.md
+++ b/README.md
@@ -46,4 +46,21 @@ with success when all assertions pass.
 - `src/main.cpp` – simple example using the board and move generator
 - `src/*Tests.cpp` – small self-contained test programs for the above components
 
+## Usage Examples
+
+Several small programs in the `examples` directory demonstrate how to work with
+the API:
+
+- `create_position.cpp` – manually set up a board and print it.
+- `generate_moves.cpp` – load a FEN string and list all legal moves.
+- `search_best_move.cpp` – use the engine to pick a move from a position.
+
+After building, run them from the `build` directory just like the main example:
+
+```bash
+./CreatePosition
+./GenerateMoves
+./SearchBestMove
+```
+
 

--- a/examples/create_position.cpp
+++ b/examples/create_position.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+#include "Board.h"
+
+int main() {
+    Board board;
+    board.clearBoard();
+    // Place white king on e1 and black king on e8
+    board.setWhiteKing(1ULL << algebraicToIndex("e1"));
+    board.setBlackKing(1ULL << algebraicToIndex("e8"));
+    // Add a white pawn on e2
+    board.setWhitePawns(1ULL << algebraicToIndex("e2"));
+
+    board.printBoard();
+    return 0;
+}

--- a/examples/generate_moves.cpp
+++ b/examples/generate_moves.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include "Board.h"
+#include "MoveGenerator.h"
+#include "PrintMoves.h"
+
+int main() {
+    Board board;
+    MoveGenerator gen;
+
+    // Load a custom position from FEN
+    board.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+
+    auto moves = gen.generateAllMoves(board, board.isWhiteToMove());
+    printMoves(moves);
+    return 0;
+}

--- a/examples/search_best_move.cpp
+++ b/examples/search_best_move.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include "Board.h"
+#include "Engine.h"
+
+int main() {
+    Board board; // start position by default
+    Engine engine;
+
+    std::string best = engine.searchBestMove(board, 2);
+    std::cout << "Best move: " << best << "\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- provide a set of small example programs
- document how to run the examples in the README
- integrate new examples into CMake build

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68859afdfbc8832ebb59818c45d4be96