### PR TITLE
Add perft example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ add_executable(GenerateMoves examples/generate_moves.cpp
     src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
 add_executable(SearchBestMove examples/search_best_move.cpp
     src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
+add_executable(Perft examples/perft.cpp
+    src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp src/Perft.cpp ${ENGINE_SOURCES})
 
 # Include directories
 target_include_directories(ChessAI PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -52,6 +54,7 @@ target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(CreatePosition PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(Perft PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 # Register tests with CTest
 add_test(NAME BoardTest COMMAND BoardTest)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ with success when all assertions pass.
 - `src/PrintMoves.*` – helper to print generated move lists
 - `src/main.cpp` – simple example using the board and move generator
 - `src/*Tests.cpp` – small self-contained test programs for the above components
+- `src/Perft.*` – helper function to run perft node counts
 
 ## Usage Examples
 
@@ -54,6 +55,7 @@ the API:
 - `create_position.cpp` – manually set up a board and print it.
 - `generate_moves.cpp` – load a FEN string and list all legal moves.
 - `search_best_move.cpp` – use the engine to pick a move from a position.
+- `perft.cpp` – calculate move counts at a given depth.
 
 After building, run them from the `build` directory just like the main example:
 
@@ -61,6 +63,7 @@ After building, run them from the `build` directory just like the main example:
 ./CreatePosition
 ./GenerateMoves
 ./SearchBestMove
+./Perft <FEN> <depth>
 ```
 
 

--- a/examples/perft.cpp
+++ b/examples/perft.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include "Board.h"
+#include "MoveGenerator.h"
+#include "Perft.h"
+
+int main(int argc, char* argv[]) {
+    Board board;
+    MoveGenerator gen;
+
+    if (argc > 1) {
+        if (!board.loadFEN(argv[1])) {
+            std::cerr << "Failed to load FEN" << std::endl;
+            return 1;
+        }
+    }
+
+    int depth = 1;
+    if (argc > 2) {
+        depth = std::stoi(argv[2]);
+    }
+
+    uint64_t nodes = perft(board, gen, depth);
+    std::cout << "Perft(" << depth << ") = " << nodes << "\n";
+    return 0;
+}

--- a/src/Perft.cpp
+++ b/src/Perft.cpp
@@ -1,0 +1,15 @@
+#include "Perft.h"
+
+uint64_t perft(Board& board, MoveGenerator& generator, int depth) {
+    if (depth == 0) return 1ULL;
+    auto moves = generator.generateAllMoves(board, board.isWhiteToMove());
+    if (depth == 1) return static_cast<uint64_t>(moves.size());
+
+    uint64_t nodes = 0ULL;
+    for (const auto& m : moves) {
+        Board copy = board; // copy board for move
+        copy.makeMove(m);
+        nodes += perft(copy, generator, depth - 1);
+    }
+    return nodes;
+}

--- a/src/Perft.h
+++ b/src/Perft.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "Board.h"
+#include "MoveGenerator.h"
+#include <cstdint>
+
+uint64_t perft(Board& board, MoveGenerator& generator, int depth);


### PR DESCRIPTION
## Summary
- implement a simple perft search
- build new `Perft` executable
- show how to run perft and reference new helper

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68859c2a652c832e91755b816c696922