### PR TITLE
Add basic UCI engine frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ add_executable(SearchBestMove examples/search_best_move.cpp
     src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
 add_executable(Perft examples/perft.cpp
     src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp src/Perft.cpp ${ENGINE_SOURCES})
+add_executable(UCI
+    src/UCI.cpp
+    src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
 
 # Include directories
 target_include_directories(ChessAI PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -62,6 +65,7 @@ target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(Perft PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PerftTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(UCI PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 # Register tests with CTest
 add_test(NAME BoardTest COMMAND BoardTest)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ the API:
 - `generate_moves.cpp` – load a FEN string and list all legal moves.
 - `search_best_move.cpp` – use the engine to pick a move from a position.
 - `perft.cpp` – calculate move counts at a given depth.
+- `UCI` – command line interface implementing the UCI protocol.
 
 After building, run them from the `build` directory just like the main example:
 
@@ -64,6 +65,7 @@ After building, run them from the `build` directory just like the main example:
 ./GenerateMoves
 ./SearchBestMove
 ./Perft <FEN> <depth>
+./UCI
 ```
 
 

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -1,0 +1,69 @@
+#include <iostream>
+#include <sstream>
+#include <string>
+#include "Board.h"
+#include "Engine.h"
+
+static std::string toInternalMove(const std::string& uci) {
+    if (uci.size() < 4) return "";
+    return uci.substr(0,2) + "-" + uci.substr(2,2);
+}
+
+static std::string toUCIMove(const std::string& move) {
+    std::string uci = move;
+    auto dash = uci.find('-');
+    if (dash != std::string::npos) uci.erase(dash,1);
+    return uci;
+}
+
+int main() {
+    Board board;
+    Engine engine;
+    std::string line;
+    std::cout.setf(std::ios::unitbuf);
+
+    while (std::getline(std::cin, line)) {
+        if (line == "uci") {
+            std::cout << "id name ChessAI" << '\n';
+            std::cout << "id author Unknown" << '\n';
+            std::cout << "uciok" << '\n';
+        } else if (line == "isready") {
+            std::cout << "readyok" << '\n';
+        } else if (line.rfind("position", 0) == 0) {
+            std::istringstream iss(line);
+            std::string token;
+            iss >> token; // position
+            iss >> token;
+            if (token == "startpos") {
+                board.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+            } else if (token == "fen") {
+                std::string fenParts[6];
+                for (int i=0;i<6 && iss>>fenParts[i];++i) {}
+                std::string fen = fenParts[0]+" "+fenParts[1]+" "+fenParts[2]+" "+fenParts[3]+" "+fenParts[4]+" "+fenParts[5];
+                board.loadFEN(fen);
+            }
+            if (iss >> token && token == "moves") {
+                while (iss >> token) {
+                    board.makeMove(toInternalMove(token));
+                }
+            }
+        } else if (line.rfind("go",0) == 0) {
+            int depth = 3;
+            std::istringstream iss(line);
+            std::string token;
+            iss >> token; // go
+            while (iss >> token) {
+                if (token == "depth" && iss >> depth) {
+                    break;
+                }
+            }
+            std::string best = engine.searchBestMove(board, depth);
+            if (best.empty()) best = "0000";
+            else best = toUCIMove(best);
+            std::cout << "bestmove " << best << '\n';
+        } else if (line == "quit") {
+            break;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement a simple UCI command loop
- build new `UCI` executable
- document running the UCI frontend

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6885a4b62c6c832eb3611b7ad2abf99d