### PR TITLE
Use magic bitboards

### DIFF
--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -9,6 +9,7 @@
 
 class MoveGenerator {
 public:
+    MoveGenerator();
     std::vector<std::string> generatePawnMoves(const Board& board, bool isWhite);
     std::vector<std::string> generateKnightMoves(const Board& board, bool isWhite);
     std::vector<std::string> generateRookMoves(const Board& board, bool isWhite);


### PR DESCRIPTION
## Summary
- initialize magic bitboards in `MoveGenerator`
- use precomputed magic tables for rook, bishop and queen attacks
- fix table generation to avoid skipping squares

## Testing
- `cmake .. && make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6888b71eeaa0832e98c6a9272897bb50