### PR TITLE
Add time control and infinite search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(ChessAI)
 
+find_package(Threads REQUIRED)
+
 include(CTest)
 enable_testing()
 
@@ -66,6 +68,8 @@ target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(Perft PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PerftTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(UCI PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+target_link_libraries(UCI PRIVATE Threads::Threads)
 
 # Register tests with CTest
 add_test(NAME BoardTest COMMAND BoardTest)

--- a/src/Engine.cpp
+++ b/src/Engine.cpp
@@ -1,6 +1,9 @@
 #include "Engine.h"
 #include <algorithm>
 #include <array>
+#include <chrono>
+#include <atomic>
+#include <iostream>
 
 // Helper to remove and get index of least significant bit
 static int popLSBIndex(uint64_t &bb) {
@@ -178,7 +181,11 @@ int Engine::evaluate(const Board& b) const {
     return score;
 }
 
-int Engine::minimax(Board& board, int depth, int alpha, int beta, bool maximizing) {
+int Engine::minimax(Board& board, int depth, int alpha, int beta, bool maximizing,
+                    const std::chrono::steady_clock::time_point& end,
+                    const std::atomic<bool>& stop) {
+    if (stop || std::chrono::steady_clock::now() >= end) return evaluate(board);
+    nodes++;
     if (depth == 0) return evaluate(board);
     auto moves = generator.generateAllMoves(board, board.isWhiteToMove());
     if (moves.empty()) return evaluate(board);
@@ -187,7 +194,7 @@ int Engine::minimax(Board& board, int depth, int alpha, int beta, bool maximizin
         for (const auto& m : moves) {
             Board copy = board;
             copy.makeMove(m);
-            int eval = minimax(copy, depth - 1, alpha, beta, false);
+            int eval = minimax(copy, depth - 1, alpha, beta, false, end, stop);
             maxEval = std::max(maxEval, eval);
             alpha = std::max(alpha, eval);
             if (beta <= alpha) break;
@@ -198,7 +205,7 @@ int Engine::minimax(Board& board, int depth, int alpha, int beta, bool maximizin
         for (const auto& m : moves) {
             Board copy = board;
             copy.makeMove(m);
-            int eval = minimax(copy, depth - 1, alpha, beta, true);
+            int eval = minimax(copy, depth - 1, alpha, beta, true, end, stop);
             minEval = std::min(minEval, eval);
             beta = std::min(beta, eval);
             if (beta <= alpha) break;
@@ -211,15 +218,58 @@ std::string Engine::searchBestMove(Board& board, int depth) {
     auto moves = generator.generateAllMoves(board, board.isWhiteToMove());
     std::string bestMove;
     int bestScore = board.isWhiteToMove() ? -1000000 : 1000000;
+    std::atomic<bool> dummyStop(false);
     for (const auto& m : moves) {
         Board copy = board;
         copy.makeMove(m);
-        int score = minimax(copy, depth - 1, -1000000, 1000000, !board.isWhiteToMove());
+        int score = minimax(copy, depth - 1, -1000000, 1000000,
+                            !board.isWhiteToMove(),
+                            std::chrono::steady_clock::time_point::max(),
+                            dummyStop);
         if (board.isWhiteToMove()) {
             if (score > bestScore) { bestScore = score; bestMove = m; }
         } else {
             if (score < bestScore) { bestScore = score; bestMove = m; }
         }
+    }
+    return bestMove;
+}
+
+std::string Engine::searchBestMoveTimed(Board& board, int maxDepth,
+                                        int timeLimitMs,
+                                        std::atomic<bool>& stopFlag) {
+    auto start = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point endTime;
+    if (timeLimitMs <= 0)
+        endTime = std::chrono::steady_clock::time_point::max();
+    else
+        endTime = start + std::chrono::milliseconds(timeLimitMs);
+
+    std::string bestMove;
+    int bestScore = 0;
+    for (int depth = 1; maxDepth == 0 || depth <= maxDepth; ++depth) {
+        nodes = 0;
+        auto moves = generator.generateAllMoves(board, board.isWhiteToMove());
+        bestScore = board.isWhiteToMove() ? -1000000 : 1000000;
+        for (const auto& m : moves) {
+            Board copy = board;
+            copy.makeMove(m);
+            int score = minimax(copy, depth - 1, -1000000, 1000000,
+                                !board.isWhiteToMove(), endTime, stopFlag);
+            if (board.isWhiteToMove()) {
+                if (score > bestScore) { bestScore = score; bestMove = m; }
+            } else {
+                if (score < bestScore) { bestScore = score; bestMove = m; }
+            }
+            if (stopFlag || std::chrono::steady_clock::now() >= endTime) break;
+        }
+        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - start)
+                          .count();
+        std::cout << "info depth " << depth << " score cp "
+                  << (board.isWhiteToMove() ? bestScore : -bestScore)
+                  << " nodes " << nodes << " time " << elapsed << '\n';
+        if (stopFlag || std::chrono::steady_clock::now() >= endTime) break;
     }
     return bestMove;
 }

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -2,12 +2,23 @@
 #include "Board.h"
 #include "MoveGenerator.h"
 #include <string>
+#include <chrono>
+#include <atomic>
 
 class Engine {
 public:
     int evaluate(const Board& board) const;
-    int minimax(Board& board, int depth, int alpha, int beta, bool maximizing);
+    int minimax(Board& board, int depth, int alpha, int beta, bool maximizing,
+                const std::chrono::steady_clock::time_point& end,
+                const std::atomic<bool>& stop);
+
     std::string searchBestMove(Board& board, int depth);
+
+    std::string searchBestMoveTimed(Board& board, int maxDepth,
+                                    int timeLimitMs,
+                                    std::atomic<bool>& stopFlag);
+
 private:
     MoveGenerator generator;
+    uint64_t nodes = 0;
 };

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -1,6 +1,9 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <thread>
+#include <atomic>
+#include <chrono>
 #include "Board.h"
 #include "Engine.h"
 
@@ -20,6 +23,10 @@ int main() {
     Board board;
     Engine engine;
     std::string line;
+    std::atomic<bool> stopFlag(false);
+    std::thread searchThread;
+    std::string bestMove;
+
     std::cout.setf(std::ios::unitbuf);
 
     while (std::getline(std::cin, line)) {
@@ -48,20 +55,50 @@ int main() {
                 }
             }
         } else if (line.rfind("go",0) == 0) {
-            int depth = 3;
+            int depth = 0;
+            int wtime = 0, btime = 0, winc = 0, binc = 0;
+            bool infinite = false;
             std::istringstream iss(line);
             std::string token;
             iss >> token; // go
             while (iss >> token) {
-                if (token == "depth" && iss >> depth) {
-                    break;
-                }
+                if (token == "depth" && iss >> depth) {}
+                else if (token == "wtime" && iss >> wtime) {}
+                else if (token == "btime" && iss >> btime) {}
+                else if (token == "winc" && iss >> winc) {}
+                else if (token == "binc" && iss >> binc) {}
+                else if (token == "infinite") infinite = true;
             }
-            std::string best = engine.searchBestMove(board, depth);
-            if (best.empty()) best = "0000";
-            else best = toUCIMove(best);
-            std::cout << "bestmove " << best << '\n';
+
+            int timeLimit = 0;
+            if (!infinite && (wtime || btime)) {
+                int remain = board.isWhiteToMove() ? wtime : btime;
+                int inc = board.isWhiteToMove() ? winc : binc;
+                timeLimit = remain / 20 + inc / 2;
+            }
+
+            stopFlag = false;
+            searchThread = std::thread([&]() {
+                bestMove = engine.searchBestMoveTimed(board, depth, timeLimit, stopFlag);
+            });
+
+            if (!infinite) {
+                searchThread.join();
+                std::string uci = bestMove.empty() ? "0000" : toUCIMove(bestMove);
+                std::cout << "bestmove " << uci << '\n';
+            }
+        } else if (line == "stop") {
+            if (searchThread.joinable()) {
+                stopFlag = true;
+                searchThread.join();
+                std::string uci = bestMove.empty() ? "0000" : toUCIMove(bestMove);
+                std::cout << "bestmove " << uci << '\n';
+            }
         } else if (line == "quit") {
+            if (searchThread.joinable()) {
+                stopFlag = true;
+                searchThread.join();
+            }
             break;
         }
     }


### PR DESCRIPTION
## Summary
- allow the engine to stop searching based on a time limit
- support running searches indefinitely until `stop`
- print search depth and node info as debug output
- enable thread support for the UCI executable

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6888c05db17c832ebaa46004a5fa9dc3