### PR TITLE
Add PV to UCI debug info

### DIFF
--- a/src/Engine.h
+++ b/src/Engine.h
@@ -4,13 +4,15 @@
 #include <string>
 #include <chrono>
 #include <atomic>
+#include <utility>
 
 class Engine {
 public:
     int evaluate(const Board& board) const;
-    int minimax(Board& board, int depth, int alpha, int beta, bool maximizing,
-                const std::chrono::steady_clock::time_point& end,
-                const std::atomic<bool>& stop);
+    std::pair<int, std::string>
+    minimax(Board& board, int depth, int alpha, int beta, bool maximizing,
+            const std::chrono::steady_clock::time_point& end,
+            const std::atomic<bool>& stop);
 
     std::string searchBestMove(Board& board, int depth);
 


### PR DESCRIPTION
## Summary
- track principal variation in `Engine::minimax`
- show PV moves in UCI 'info' output

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6888c3e3a42c832ead03187b3a826bc8