### PR TITLE
Improve evaluation function with mobility and development

### DIFF
--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -279,7 +279,7 @@ MoveGenerator::MoveGenerator() {
     Magic::init();
 }
 
-std::vector<std::string> MoveGenerator::generatePawnMoves(const Board& board, bool isWhite) {
+std::vector<std::string> MoveGenerator::generatePawnMoves(const Board& board, bool isWhite) const {
     std::vector<std::string> moves;
     uint64_t pawns = isWhite ? board.getWhitePawns() : board.getBlackPawns();
     uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
@@ -399,7 +399,7 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board& board, bo
 
 
 
-void MoveGenerator::addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift) {
+void MoveGenerator::addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift) const {
     for (int from = 0; moveBoard; moveBoard &= moveBoard - 1) {
         int to = lsbIndex(moveBoard);
         from = to - shift; // Calculate starting square
@@ -407,7 +407,7 @@ void MoveGenerator::addMoves(std::vector<std::string>& moves, uint64_t pawns, ui
     }
 }
 
-std::vector<std::string> MoveGenerator::generateKnightMoves(const Board& board, bool isWhite) {
+std::vector<std::string> MoveGenerator::generateKnightMoves(const Board& board, bool isWhite) const {
     std::vector<std::string> moves;
     uint64_t knights = isWhite ? board.getWhiteKnights() : board.getBlackKnights();
     uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
@@ -435,7 +435,7 @@ std::vector<std::string> MoveGenerator::generateKnightMoves(const Board& board, 
     return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateRookMoves(const Board& board, bool isWhite) {
+std::vector<std::string> MoveGenerator::generateRookMoves(const Board& board, bool isWhite) const {
     std::vector<std::string> moves;
     uint64_t rooks = isWhite ? board.getWhiteRooks() : board.getBlackRooks();
     uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
@@ -451,7 +451,7 @@ std::vector<std::string> MoveGenerator::generateRookMoves(const Board& board, bo
     return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateBishopMoves(const Board& board, bool isWhite) {
+std::vector<std::string> MoveGenerator::generateBishopMoves(const Board& board, bool isWhite) const {
     std::vector<std::string> moves;
     uint64_t bishops = isWhite ? board.getWhiteBishops() : board.getBlackBishops();
     uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
@@ -467,7 +467,7 @@ std::vector<std::string> MoveGenerator::generateBishopMoves(const Board& board, 
     return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateQueenMoves(const Board& board, bool isWhite) {
+std::vector<std::string> MoveGenerator::generateQueenMoves(const Board& board, bool isWhite) const {
     std::vector<std::string> moves;
     uint64_t queens = isWhite ? board.getWhiteQueens() : board.getBlackQueens();
     uint64_t ownPieces = isWhite ? board.getWhitePieces() : board.getBlackPieces();
@@ -483,7 +483,7 @@ std::vector<std::string> MoveGenerator::generateQueenMoves(const Board& board, b
     return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateKingMoves(const Board& board, bool isWhite) {
+std::vector<std::string> MoveGenerator::generateKingMoves(const Board& board, bool isWhite) const {
     std::vector<std::string> moves;
     uint64_t king = isWhite ? board.getWhiteKing() : board.getBlackKing();
     if (!king) return moves;
@@ -531,7 +531,7 @@ std::vector<std::string> MoveGenerator::generateKingMoves(const Board& board, bo
     return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateAllMoves(const Board& board, bool isWhite) {
+std::vector<std::string> MoveGenerator::generateAllMoves(const Board& board, bool isWhite) const {
     std::vector<std::string> all;
     auto append = [&all](const std::vector<std::string>& mv) {
         all.insert(all.end(), mv.begin(), mv.end());

--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -10,14 +10,14 @@
 class MoveGenerator {
 public:
     MoveGenerator();
-    std::vector<std::string> generatePawnMoves(const Board& board, bool isWhite);
-    std::vector<std::string> generateKnightMoves(const Board& board, bool isWhite);
-    std::vector<std::string> generateRookMoves(const Board& board, bool isWhite);
-    std::vector<std::string> generateBishopMoves(const Board& board, bool isWhite);
-    std::vector<std::string> generateQueenMoves(const Board& board, bool isWhite);
-    std::vector<std::string> generateKingMoves(const Board& board, bool isWhite);
-    std::vector<std::string> generateAllMoves(const Board& board, bool isWhite);
-    void addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift);
+    std::vector<std::string> generatePawnMoves(const Board& board, bool isWhite) const;
+    std::vector<std::string> generateKnightMoves(const Board& board, bool isWhite) const;
+    std::vector<std::string> generateRookMoves(const Board& board, bool isWhite) const;
+    std::vector<std::string> generateBishopMoves(const Board& board, bool isWhite) const;
+    std::vector<std::string> generateQueenMoves(const Board& board, bool isWhite) const;
+    std::vector<std::string> generateKingMoves(const Board& board, bool isWhite) const;
+    std::vector<std::string> generateAllMoves(const Board& board, bool isWhite) const;
+    void addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift) const;
 };
 
 std::string indexToAlgebraic(int index);


### PR DESCRIPTION
## Summary
- enable const generation functions for mobility calculations
- add mobility and development scoring to `Engine::evaluate`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6888c92a00ac832ea725d3e673c43533