### PR TITLE
Add illegal move validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ add_executable(KingMoveTests
     src/MoveGenerator.cpp
     src/PrintMoves.cpp ${ENGINE_SOURCES})
 
+add_executable(IllegalMoveTests
+    src/IllegalMoveTests.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 add_executable(PerftTest
     src/PerftTest.cpp
     src/Board.cpp
@@ -62,6 +68,7 @@ target_include_directories(PawnMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KnightMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(IllegalMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(CreatePosition PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -78,6 +85,7 @@ add_test(NAME KnightMoveTests COMMAND KnightMoveTests)
 add_test(NAME SliderMoveTests COMMAND SliderMoveTests)
 add_test(NAME KingMoveTests COMMAND KingMoveTests)
 add_test(NAME PerftTest COMMAND PerftTest)
+add_test(NAME IllegalMoveTests COMMAND IllegalMoveTests)
 
 
 

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,4 +1,5 @@
 #include "Board.h"
+#include "MoveGenerator.h"
 #include <iostream>
 #include <sstream>
 #include <cctype>
@@ -103,12 +104,22 @@ int algebraicToIndex(const std::string& sq) {
     return rank * 8 + file;
 }
 
-void Board::makeMove(const std::string& move) {
+bool Board::makeMove(const std::string& move) {
     auto dash = move.find('-');
-    if (dash == std::string::npos) return;
+    if (dash == std::string::npos) return false;
     int from = algebraicToIndex(move.substr(0, 2));
     int to = algebraicToIndex(move.substr(dash + 1, 2));
-    if (from < 0 || to < 0) return;
+    if (from < 0 || to < 0) return false;
+
+    // Verify the move is legal using the move generator
+    MoveGenerator gen;
+    auto legal = gen.generateAllMoves(*this, isWhiteToMove());
+    std::string prefix = move.substr(0,5);
+    bool found = false;
+    for (auto &m : legal) {
+        if (m.substr(0,5) == prefix) { found = true; break; }
+    }
+    if (!found) return false;
     uint64_t fromMask = 1ULL << from;
     uint64_t toMask = 1ULL << to;
 
@@ -124,8 +135,9 @@ void Board::makeMove(const std::string& move) {
           movePiece(whiteRooks) || movePiece(whiteQueens) || movePiece(whiteKing) ||
           movePiece(blackPawns) || movePiece(blackKnights) || movePiece(blackBishops) ||
           movePiece(blackRooks) || movePiece(blackQueens) || movePiece(blackKing))) {
-        return;
+        return false;
     }
 
     whiteToMove = !whiteToMove;
+    return true;
 }

--- a/src/Board.h
+++ b/src/Board.h
@@ -61,7 +61,9 @@ public:
     void clearBoard();  // Utility function to reset the board state
     void printBoard() const;
     bool loadFEN(const std::string& fen);
-    void makeMove(const std::string& move);
+    // Makes a move in "e2-e4" style notation if it is legal.
+    // Returns true on success and false if the move is illegal.
+    bool makeMove(const std::string& move);
 };
 
 int algebraicToIndex(const std::string& sq);

--- a/src/IllegalMoveTests.cpp
+++ b/src/IllegalMoveTests.cpp
@@ -1,0 +1,39 @@
+#include "Board.h"
+#include <cassert>
+#include <iostream>
+
+void testIllegalPawnLeap() {
+    Board board; // start position
+    bool ok = board.makeMove("e2-e5");
+    assert(!ok); // pawn cannot move three squares
+}
+
+void testMoveFromEmptySquare() {
+    Board board; // start position
+    bool ok = board.makeMove("e3-e4");
+    assert(!ok);
+}
+
+void testWrongSidePiece() {
+    Board board; // start position white to move
+    bool ok = board.makeMove("a7-a6");
+    assert(!ok); // black pawn cannot move when white to move
+}
+
+void testLegalMove() {
+    Board board;
+    bool ok = board.makeMove("e2-e4");
+    assert(ok);
+    // After move, e4 should contain a white pawn
+    int from = algebraicToIndex("e4");
+    assert(board.getWhitePawns() & (1ULL << from));
+}
+
+int main() {
+    testIllegalPawnLeap();
+    testMoveFromEmptySquare();
+    testWrongSidePiece();
+    testLegalMove();
+    std::cout << "\nIllegal move tests passed!" << std::endl;
+    return 0;
+}

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -51,7 +51,9 @@ int main() {
             }
             if (iss >> token && token == "moves") {
                 while (iss >> token) {
-                    board.makeMove(toInternalMove(token));
+                    if (!board.makeMove(toInternalMove(token))) {
+                        std::cerr << "Illegal move ignored: " << token << '\n';
+                    }
                 }
             }
         } else if (line.rfind("go",0) == 0) {


### PR DESCRIPTION
## Summary
- verify move legality in `Board::makeMove`
- report ignored illegal moves in UCI interface
- add a dedicated test for illegal moves

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6888d74389a8832e976d7a61b41ce70a