### PR TITLE
Implement legality checks for moves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ add_executable(KingMoveTests
     src/MoveGenerator.cpp
     src/PrintMoves.cpp ${ENGINE_SOURCES})
 
+add_executable(IllegalMoveTests
+    src/IllegalMoveTests.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 add_executable(PerftTest
     src/PerftTest.cpp
     src/Board.cpp
@@ -62,6 +68,7 @@ target_include_directories(PawnMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KnightMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(IllegalMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(CreatePosition PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -78,6 +85,7 @@ add_test(NAME KnightMoveTests COMMAND KnightMoveTests)
 add_test(NAME SliderMoveTests COMMAND SliderMoveTests)
 add_test(NAME KingMoveTests COMMAND KingMoveTests)
 add_test(NAME PerftTest COMMAND PerftTest)
+add_test(NAME IllegalMoveTests COMMAND IllegalMoveTests)
 
 
 

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,4 +1,5 @@
 #include "Board.h"
+#include "MoveGenerator.h"
 #include <iostream>
 #include <sstream>
 #include <cctype>
@@ -103,7 +104,22 @@ int algebraicToIndex(const std::string& sq) {
     return rank * 8 + file;
 }
 
+bool Board::isMoveLegal(const std::string& move) const {
+    if (move.size() < 5) return false;
+    MoveGenerator gen;
+    auto moves = gen.generateAllMoves(*this, whiteToMove);
+    std::string check = move.substr(0,5);
+    for (const auto& m : moves) {
+        if (m.substr(0,5) == check) return true;
+    }
+    return false;
+}
+
 void Board::makeMove(const std::string& move) {
+    if (!isMoveLegal(move)) {
+        std::cerr << "Illegal move attempted: " << move << "\n";
+        return;
+    }
     auto dash = move.find('-');
     if (dash == std::string::npos) return;
     int from = algebraicToIndex(move.substr(0, 2));

--- a/src/Board.h
+++ b/src/Board.h
@@ -61,6 +61,7 @@ public:
     void clearBoard();  // Utility function to reset the board state
     void printBoard() const;
     bool loadFEN(const std::string& fen);
+    bool isMoveLegal(const std::string& move) const;
     void makeMove(const std::string& move);
 };
 

--- a/src/IllegalMoveTests.cpp
+++ b/src/IllegalMoveTests.cpp
@@ -1,0 +1,21 @@
+#include "Board.h"
+#include <cassert>
+#include <iostream>
+
+void testIllegalMove() {
+    Board board;
+    board.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    assert(!board.isMoveLegal("e2-e5"));
+}
+
+void testLegalMove() {
+    Board board;
+    assert(board.isMoveLegal("e2-e4"));
+}
+
+int main() {
+    testIllegalMove();
+    testLegalMove();
+    std::cout << "\nIllegal move tests passed!\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add Board::isMoveLegal and check it in makeMove
- integrate new IllegalMoveTests program
- register new test in CMake

## Testing
- `cmake ..`
- `make -j $(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6888d74389a8832e976d7a61b41ce70a