### PR TITLE
Rename engine to Aphelion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(ChessAI)
+project(Aphelion)
 
 find_package(Threads REQUIRED)
 
@@ -57,7 +57,7 @@ add_executable(SearchBestMove examples/search_best_move.cpp
     src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
 add_executable(Perft examples/perft.cpp
     src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp src/Perft.cpp ${ENGINE_SOURCES})
-add_executable(ChessAI
+add_executable(Aphelion
     src/UCI.cpp
     src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
 
@@ -74,9 +74,9 @@ target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(Perft PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PerftTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_include_directories(ChessAI PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(Aphelion PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
-target_link_libraries(ChessAI PRIVATE Threads::Threads)
+target_link_libraries(Aphelion PRIVATE Threads::Threads)
 
 # Register tests with CTest
 add_test(NAME BoardTest COMMAND BoardTest)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChessAI
+# Aphelion
 
 A simple C++ project exploring chess board representation and move generation.
 
@@ -13,7 +13,7 @@ cmake ..
 make
 ```
 
-This will create several executables such as `Example` (a demo program) and `ChessAI` (the UCI engine) along with the various test programs.
+This will create several executables such as `Example` (a demo program) and `Aphelion` (the UCI engine) along with the various test programs.
 
 ## Running the Example
 
@@ -56,7 +56,7 @@ the API:
 - `generate_moves.cpp` – load a FEN string and list all legal moves.
 - `search_best_move.cpp` – use the engine to pick a move from a position.
 - `perft.cpp` – calculate move counts at a given depth.
-- `ChessAI` – command line interface implementing the UCI protocol.
+- `Aphelion` – command line interface implementing the UCI protocol.
 
 After building, run them from the `build` directory just like the main example:
 
@@ -65,7 +65,7 @@ After building, run them from the `build` directory just like the main example:
 ./GenerateMoves
 ./SearchBestMove
 ./Perft <FEN> <depth>
-./ChessAI
+./Aphelion
 ```
 
 

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -31,7 +31,7 @@ int main() {
 
     while (std::getline(std::cin, line)) {
         if (line == "uci") {
-            std::cout << "id name ChessAI 0.1" << '\n';
+            std::cout << "id name Aphelion 0.1" << '\n';
             std::cout << "id author Matt LaDuke and ChatGPT" << '\n';
             std::cout << "uciok" << '\n';
         } else if (line == "isready") {


### PR DESCRIPTION
## Summary
- rename the project and executable from ChessAI to **Aphelion**
- update README references to the new engine
- report the new engine name through UCI

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6888e646106c832ebe90c6ae0032a2d2