### PR TITLE
Add full castling validations

### DIFF
--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -18,6 +18,9 @@ public:
     std::vector<std::string> generateKingMoves(const Board& board, bool isWhite) const;
     std::vector<std::string> generateAllMoves(const Board& board, bool isWhite) const;
     void addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift) const;
+
+    bool isSquareAttacked(const Board& board, int square, bool byWhite) const;
+    bool isKingInCheck(const Board& board, bool white) const;
 };
 
 std::string indexToAlgebraic(int index);

--- a/test/KingMoveTests.cpp
+++ b/test/KingMoveTests.cpp
@@ -37,9 +37,54 @@ void testCastling() {
     assert(bK && bQ);
 }
 
+void testNoCastlingWhileInCheck() {
+    Board b;
+    b.clearBoard();
+    b.setWhiteKing(1ULL << 4);   // e1
+    b.setWhiteRooks((1ULL<<0) | (1ULL<<7));
+    b.setBlackRooks(1ULL << 12); // e2 giving check
+    b.setBlackKing(1ULL << 60);
+    b.setCastleWK(true);
+    b.setCastleWQ(true);
+    MoveGenerator g;
+    auto moves = g.generateKingMoves(b, true);
+    for (auto &m : moves) {
+        assert(m.find("Castle") == std::string::npos);
+    }
+}
+
+void testNoCastlingThroughCheck() {
+    Board b;
+    b.clearBoard();
+    b.setWhiteKing(1ULL << 4);
+    b.setWhiteRooks((1ULL<<0) | (1ULL<<7));
+    b.setBlackRooks(1ULL << 21); // f3 attacking f1
+    b.setBlackKing(1ULL << 60);
+    b.setCastleWK(true);
+    MoveGenerator g;
+    auto moves = g.generateKingMoves(b, true);
+    for (auto &m : moves) {
+        assert(m.find("Castle Kingside") == std::string::npos);
+    }
+}
+
+void testRookMoveDisablesCastling() {
+    Board b;
+    b.loadFEN("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1");
+    b.makeMove("h1-h2");
+    MoveGenerator g;
+    auto moves = g.generateKingMoves(b, true);
+    for (auto &m : moves) {
+        assert(m.find("Castle Kingside") == std::string::npos);
+    }
+}
+
 int main() {
     testBasicKingMoves();
     testCastling();
+    testNoCastlingWhileInCheck();
+    testNoCastlingThroughCheck();
+    testRookMoveDisablesCastling();
     std::cout << "\nAll king move tests passed!" << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- ensure castling legality checks for king in check, passing through check and unmoved pieces
- update Board::makeMove to maintain castling rights and handle rook moves
- expose attack helpers and king check helpers in MoveGenerator
- extend king move tests for various castling rule violations

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6888efc0bde8832eb31567b0b5a7f9ef