### PR TITLE
Fix move legality when in check

### DIFF
--- a/src/Board.h
+++ b/src/Board.h
@@ -63,6 +63,8 @@ public:
     bool loadFEN(const std::string& fen);
     bool isMoveLegal(const std::string& move) const;
     void makeMove(const std::string& move);
+private:
+    void applyMove(const std::string& move);
 };
 
 int algebraicToIndex(const std::string& sq);


### PR DESCRIPTION
## Summary
- update move legality check to verify king safety
- factor out an `applyMove` helper used by `makeMove` and legality checks

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688909b41b10832e894dfbcd5686424a