### PR TITLE
Implement quiescence search

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,6 @@ After building, run them from the `build` directory just like the main example:
 - Minimax search with alpha-beta pruning, principal variation search and basic time management.
 - Transposition tables with Zobrist hashing for reusing evaluated positions.
 - Command-line UCI engine along with example programs for move generation and search.
+- Quiescence search to reduce horizon effects in tactical positions.
 
 

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -104,6 +104,13 @@ int algebraicToIndex(const std::string& sq) {
     return rank * 8 + file;
 }
 
+Board::Color Board::pieceColorAt(int index) const {
+    uint64_t mask = 1ULL << index;
+    if (getWhitePieces() & mask) return Color::White;
+    if (getBlackPieces() & mask) return Color::Black;
+    return Color::None;
+}
+
 bool Board::isMoveLegal(const std::string& move) const {
     if (move.size() < 5) return false;
     MoveGenerator gen;

--- a/src/Board.h
+++ b/src/Board.h
@@ -14,6 +14,9 @@ private:
 public:
     Board();
 
+    enum class Color { None, White, Black };
+    Color pieceColorAt(int index) const;
+
     bool isWhiteToMove() const { return whiteToMove; }
     bool canCastleWK() const { return castleWK; }
     bool canCastleWQ() const { return castleWQ; }

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -28,6 +28,9 @@ public:
                                     std::atomic<bool>& stopFlag);
 
 private:
+    int quiescence(Board& board, int alpha, int beta, bool maximizing,
+                   const std::chrono::steady_clock::time_point& end,
+                   const std::atomic<bool>& stop);
     MoveGenerator generator;
     uint64_t nodes = 0;
     TranspositionTable tt;


### PR DESCRIPTION
## Summary
- support quiescence search to reduce tactical horizon effects
- expose board piece color for capture detection
- integrate quiescence search into minimax
- document quiescence search in README

## Testing
- `cmake ..`
- `make -j2`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68892370b23c832ea1167622b62fabbf