### PR TITLE
Improve search speed with move ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,6 @@ After building, run them from the `build` directory just like the main example:
 - Opening book integration for common starting positions.
 - Endgame tablebase lookup for perfect play in simplified endings.
 - Parallel root search to utilize multiple CPU cores during move calculation.
+- Move ordering using capture heuristics for faster alpha-beta pruning.
 
 


### PR DESCRIPTION
## Summary
- score moves using MVV/LVA style heuristics
- order moves in search functions based on capture value
- document new move ordering feature in README

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68893479776c832e9b4f614ca342c1c3