### PR TITLE
Implement go infinite and stop commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,6 @@ After building, run them from the `build` directory just like the main example:
 - Endgame tablebase lookup for perfect play in simplified endings.
 - Parallel root search to utilize multiple CPU cores during move calculation.
 - Move ordering using capture heuristics for faster alpha-beta pruning.
+- Supports `go infinite` and `stop` commands for indefinite search sessions.
 
 

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -55,6 +55,10 @@ int main() {
                 }
             }
         } else if (line.rfind("go",0) == 0) {
+            if (searchThread.joinable()) {
+                stopFlag = true;
+                searchThread.join();
+            }
             int depth = 0;
             int wtime = 0, btime = 0, winc = 0, binc = 0;
             bool infinite = false;


### PR DESCRIPTION
## Summary
- ensure prior search threads are stopped when starting a new `go` command
- document UCI `go infinite` and `stop` commands

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688b7b8004f8832e886e6d7b1ad704e7