### PR TITLE
Implement legal move generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ add_executable(GamePhaseTests
     src/MoveGenerator.cpp
     src/PrintMoves.cpp ${ENGINE_SOURCES})
 
+add_executable(LegalMoveGenerationTest
+    test/LegalMoveGenerationTest.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 add_executable(PerftTest
     test/PerftTest.cpp
     src/Board.cpp
@@ -84,6 +90,7 @@ target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(IllegalMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GamePhaseTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(LegalMoveGenerationTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(CreatePosition PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -102,6 +109,7 @@ add_test(NAME KingMoveTests COMMAND KingMoveTests)
 add_test(NAME PerftTest COMMAND PerftTest)
 add_test(NAME IllegalMoveTests COMMAND IllegalMoveTests)
 add_test(NAME GamePhaseTests COMMAND GamePhaseTests)
+add_test(NAME LegalMoveGenerationTest COMMAND LegalMoveGenerationTest)
 
 
 

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -298,6 +298,16 @@ std::vector<std::string> MoveGenerator::generateAllMoves(const Board& board, boo
     return all;
 }
 
+std::vector<std::string> MoveGenerator::generateLegalMoves(const Board& board, bool isWhite) const {
+    auto pseudo = generateAllMoves(board, isWhite);
+    std::vector<std::string> legal;
+    for (const auto& mv : pseudo) {
+        if (board.isMoveLegal(mv))
+            legal.push_back(mv);
+    }
+    return legal;
+}
+
 bool MoveGenerator::isSquareAttacked(const Board& board, int square, bool byWhite) const {
     uint64_t occ = board.getWhitePieces() | board.getBlackPieces();
     uint64_t mask = 1ULL << square;

--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -17,6 +17,7 @@ public:
     std::vector<std::string> generateQueenMoves(const Board& board, bool isWhite) const;
     std::vector<std::string> generateKingMoves(const Board& board, bool isWhite) const;
     std::vector<std::string> generateAllMoves(const Board& board, bool isWhite) const;
+    std::vector<std::string> generateLegalMoves(const Board& board, bool isWhite) const;
     void addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift) const;
 
     bool isSquareAttacked(const Board& board, int square, bool byWhite) const;

--- a/test/LegalMoveGenerationTest.cpp
+++ b/test/LegalMoveGenerationTest.cpp
@@ -1,0 +1,40 @@
+#include "Board.h"
+#include "MoveGenerator.h"
+#include "PrintMoves.h"
+#include <cassert>
+#include <iostream>
+
+void testPinnedRook() {
+    Board board;
+    board.clearBoard();
+    board.setWhiteKing(1ULL << 2);      // c1
+    board.setWhiteRooks(1ULL << 1);     // b1
+    board.setBlackRooks(1ULL << 0);     // a1
+    board.setBlackKing(1ULL << 63);     // h8 (arbitrary)
+
+    MoveGenerator gen;
+    auto pseudo = gen.generateAllMoves(board, true);
+    auto legal = gen.generateLegalMoves(board, true);
+
+
+    bool hasIllegal = false;
+    for (const auto& m : pseudo) {
+        if (m.rfind("b1-", 0) == 0 && m != "b1-a1") {
+            hasIllegal = true;
+            break;
+        }
+    }
+    assert(hasIllegal);
+
+    for (const auto& m : legal) {
+        if (m.rfind("b1-", 0) == 0 && m != "b1-a1") {
+            assert(false && "illegal move returned by generateLegalMoves");
+        }
+    }
+}
+
+int main() {
+    testPinnedRook();
+    std::cout << "\nLegal move generation test passed!\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `generateLegalMoves` to the move generator
- wire it up in the build system
- include a test to verify pinned-piece scenarios are filtered correctly

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688b7d782d98832e91332b5099477d38