### PR TITLE
Fix checkmate detection

### DIFF
--- a/examples/generate_moves.cpp
+++ b/examples/generate_moves.cpp
@@ -3,12 +3,18 @@
 #include "MoveGenerator.h"
 #include "PrintMoves.h"
 
-int main() {
+int main(int argc, char* argv[]) {
     Board board;
     MoveGenerator gen;
 
-    // Load a custom position from FEN
-    board.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    if (argc > 1) {
+        if (!board.loadFEN(argv[1])) {
+            std::cerr << "Failed to load FEN" << std::endl;
+            return 1;
+        }
+    } else {
+        board.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    }
 
     auto moves = gen.generateAllMoves(board, board.isWhiteToMove());
     printMoves(moves);

--- a/src/EngineSearch.cpp
+++ b/src/EngineSearch.cpp
@@ -204,7 +204,13 @@ std::pair<int, std::string> Engine::minimax(
     std::sort(moves.begin(), moves.end(), [&](const std::string& a, const std::string& b) {
         return moveScore(board, a, generator) > moveScore(board, b, generator);
     });
-    if (moves.empty()) return {evaluate(board), ""};
+    if (moves.empty()) {
+        if (generator.isKingInCheck(board, board.isWhiteToMove())) {
+            int mateScore = board.isWhiteToMove() ? -1000000 : 1000000;
+            return {mateScore, ""};
+        }
+        return {0, ""}; // stalemate
+    }
     if (maximizing) {
         int bestEval = -1000000;
         std::string bestPV;


### PR DESCRIPTION
## Summary
- allow the generate_moves example to load a FEN from argv
- detect checkmate and stalemate in the search when no moves are available

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688baabbe1d0832e85668a8dc78eabaa