### PR TITLE
Enhance search heuristics

### DIFF
--- a/src/Engine.h
+++ b/src/Engine.h
@@ -22,7 +22,7 @@ public:
     std::pair<int, std::string>
     minimax(Board& board, int depth, int alpha, int beta, bool maximizing,
             const std::chrono::steady_clock::time_point& end,
-            const std::atomic<bool>& stop);
+            const std::atomic<bool>& stop, int ply = 0);
 
     std::string searchBestMove(Board& board, int depth);
 


### PR DESCRIPTION
## Summary
- add killer move and history heuristic tables
- support late move reductions and aspiration windows
- reset heuristics for each search

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688bc4eb3f0c832eb038bfadd21d77cf