### PR TITLE
Improve evaluation and openings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After building, run them from the `build` directory just like the main example:
 
 - Board representation with FEN parsing/printing and comprehensive move generation.
 - Perft utilities and unit tests for move generation correctness.
-- Evaluation function using piece-square tables, mobility and development bonuses, with game-phase awareness.
+- Evaluation function using piece-square tables, mobility and development bonuses, with game-phase awareness and a bishop pair bonus.
 - Minimax search with alpha-beta pruning, principal variation search and basic time management.
 - Transposition tables with Zobrist hashing for reusing evaluated positions.
 - Command-line UCI engine along with example programs for move generation and search.

--- a/src/EngineEvaluation.cpp
+++ b/src/EngineEvaluation.cpp
@@ -127,11 +127,15 @@ int Engine::evaluate(const Board& b) const {
         int sq = popLSBIndex(pieces);
         score += bishop + bishopTable[sq];
     }
+    if (popcount64(b.getWhiteBishops()) >= 2)
+        score += 50; // bishop pair bonus
     pieces = b.getBlackBishops();
     while (pieces) {
         int sq = popLSBIndex(pieces);
         score -= bishop + bishopTable[mirror(sq)];
     }
+    if (popcount64(b.getBlackBishops()) >= 2)
+        score -= 50; // bishop pair bonus
 
     pieces = b.getWhiteRooks();
     while (pieces) {

--- a/src/OpeningBook.cpp
+++ b/src/OpeningBook.cpp
@@ -4,6 +4,8 @@ OpeningBook::OpeningBook() {
     // Very small built-in opening book
     book["rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"] = "e2-e4";
     book["rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"] = "e7-e5";
+    book["rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2"] = "g1-f3";
+    book["rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq - 0 2"] = "d7-d5";
 }
 
 std::optional<std::string> OpeningBook::getBookMove(const Board& board) const {


### PR DESCRIPTION
## Summary
- reward the bishop pair during evaluation
- add a few more opening book moves
- document bishop pair scoring in README

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688bd3cfae60832ea65b1cc8480fea0b