### PR TITLE
Add hashfull and nps reporting

### DIFF
--- a/src/TranspositionTable.h
+++ b/src/TranspositionTable.h
@@ -21,6 +21,17 @@ public:
     explicit TranspositionTable(size_t size = DEFAULT_SIZE)
         : table(size) {}
 
+    size_t size() const { return table.size(); }
+
+    size_t used() const {
+        size_t count = 0;
+        for (const auto& slot : table) {
+            if (slot.depth.load(std::memory_order_relaxed) != -1)
+                ++count;
+        }
+        return count;
+    }
+
     void store(uint64_t key, const TTEntry& entry) {
         auto& slot = table[key % table.size()];
         int curDepth = slot.depth.load(std::memory_order_relaxed);


### PR DESCRIPTION
## Summary
- expose transposition table usage helpers
- display hashfull and NPS metrics in timed search info output

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_688bddd55618832eb9c764499d7757b1