### PR TITLE
Add hashfull and nps reporting

### DIFF
--- a/src/EngineSearch.cpp
+++ b/src/EngineSearch.cpp
@@ -359,6 +359,7 @@ std::string Engine::searchBestMoveTimed(Board& board, int maxDepth,
     bool lastDepthComplete = true;
     for (int depth = 1; maxDepth == 0 || depth <= maxDepth; ++depth) {
         nodes = 0;
+        auto depthStart = std::chrono::steady_clock::now();
         auto pseudoMoves = generator.generateAllMoves(board, board.isWhiteToMove());
         std::vector<std::string> moves;
         for (const auto& mv : pseudoMoves) {
@@ -368,6 +369,12 @@ std::string Engine::searchBestMoveTimed(Board& board, int maxDepth,
         std::sort(moves.begin(), moves.end(), [&](const std::string& a, const std::string& b) {
             return moveScore(board, a, generator) > moveScore(board, b, generator);
         });
+        if (depth > 1 && !completedMove.empty()) {
+            auto it = std::find(moves.begin(), moves.end(), completedMove);
+            if (it != moves.end()) {
+                std::rotate(moves.begin(), it, it + 1);
+            }
+        }
         bestScore = board.isWhiteToMove() ? -1000000 : 1000000;
         bestPV.clear();
         lastDepthComplete = true;
@@ -396,7 +403,7 @@ std::string Engine::searchBestMoveTimed(Board& board, int maxDepth,
                 lastDepthComplete = false;
         }
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::steady_clock::now() - start)
+                          std::chrono::steady_clock::now() - depthStart)
                           .count();
         std::string pvUCI;
         {
@@ -407,9 +414,13 @@ std::string Engine::searchBestMoveTimed(Board& board, int maxDepth,
                 pvUCI += toUCIMove(token);
             }
         }
+        int hashPercent = static_cast<int>(tt.used() * 1000 / tt.size());
+        uint64_t nodeCount = nodes.load();
+        uint64_t nps = elapsed > 0 ? (nodeCount * 1000 / elapsed) : nodeCount;
         std::cout << "info depth " << depth << " score cp "
                   << (board.isWhiteToMove() ? bestScore : -bestScore)
-                  << " nodes " << nodes << " time " << elapsed;
+                  << " nodes " << nodeCount << " nps " << nps
+                  << " hashfull " << hashPercent << " time " << elapsed;
         if (!pvUCI.empty())
             std::cout << " pv " << pvUCI;
         std::cout << '\n';

--- a/src/TranspositionTable.h
+++ b/src/TranspositionTable.h
@@ -19,12 +19,18 @@ struct TTSlot {
 class TranspositionTable {
 public:
     explicit TranspositionTable(size_t size = DEFAULT_SIZE)
-        : table(size) {}
+        : table(size), usedSlots(0) {}
+
+    size_t size() const { return table.size(); }
+
+    size_t used() const { return usedSlots.load(std::memory_order_relaxed); }
 
     void store(uint64_t key, const TTEntry& entry) {
         auto& slot = table[key % table.size()];
         int curDepth = slot.depth.load(std::memory_order_relaxed);
         if (curDepth <= entry.depth) {
+            if (curDepth == -1)
+                usedSlots.fetch_add(1, std::memory_order_relaxed);
             slot.key.store(key, std::memory_order_relaxed);
             slot.depth.store(entry.depth, std::memory_order_relaxed);
             slot.value.store(entry.value, std::memory_order_relaxed);
@@ -46,8 +52,10 @@ public:
         for (auto& s : table) {
             s.depth.store(-1, std::memory_order_relaxed);
         }
+        usedSlots.store(0, std::memory_order_relaxed);
     }
 private:
     static constexpr size_t DEFAULT_SIZE = 1 << 20;
     std::vector<TTSlot> table;
+    std::atomic<size_t> usedSlots;
 };


### PR DESCRIPTION
## Summary
- expose transposition table usage helpers
- display hashfull and NPS metrics in timed search info output
- reduce overhead of `hashfull` by tracking used slots incrementally
- prioritize previous iteration's best move in timed search

## Testing
- `cmake -B build`
- `cmake --build build`
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_688bddd55618832eb9c764499d7757b1