### PR TITLE
Implement stalemate detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,12 @@ add_executable(LegalMoveGenerationTest
     src/MoveGenerator.cpp
     src/PrintMoves.cpp ${ENGINE_SOURCES})
 
+add_executable(StalemateTest
+    test/StalemateTest.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 add_executable(PerftTest
     test/PerftTest.cpp
     src/Board.cpp
@@ -98,6 +104,7 @@ target_include_directories(IllegalMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GamePhaseTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(DrawRuleTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(LegalMoveGenerationTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(StalemateTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(CreatePosition PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -118,6 +125,7 @@ add_test(NAME IllegalMoveTests COMMAND IllegalMoveTests)
 add_test(NAME GamePhaseTests COMMAND GamePhaseTests)
 add_test(NAME DrawRuleTests COMMAND DrawRuleTests)
 add_test(NAME LegalMoveGenerationTest COMMAND LegalMoveGenerationTest)
+add_test(NAME StalemateTest COMMAND StalemateTest)
 
 
 

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -284,3 +284,11 @@ int Board::repetitionCount() const {
     auto it = repetitionTable.find(key);
     return it != repetitionTable.end() ? it->second : 0;
 }
+
+bool Board::isStalemate() const {
+    MoveGenerator gen;
+    if (gen.isKingInCheck(*this, whiteToMove))
+        return false;
+    auto moves = gen.generateLegalMoves(*this, whiteToMove);
+    return moves.empty();
+}

--- a/src/Board.h
+++ b/src/Board.h
@@ -54,6 +54,7 @@ public:
     bool isFiftyMoveDraw() const { return halfmoveClock >= 100; }
     bool isThreefoldRepetition() const;
     int repetitionCount() const;
+    bool isStalemate() const;
 
     // Setters for testing
     void setWhitePawns(uint64_t value) { whitePawns = value; }

--- a/test/StalemateTest.cpp
+++ b/test/StalemateTest.cpp
@@ -1,0 +1,16 @@
+#include "Board.h"
+#include <cassert>
+#include <iostream>
+
+void testStalemate() {
+    Board b;
+    b.loadFEN("7k/5Q2/6K1/8/8/8/8/8 b - - 0 1");
+    assert(b.isStalemate());
+    std::cout << "[✔] Stalemate detected\n";
+}
+
+int main() {
+    testStalemate();
+    std::cout << "All tests done\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `isStalemate` helper to `Board`
- detect stalemate using move generator
- add a simple test for stalemate detection
- wire up new test executable in CMake

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688c0875cc00832ebb33c0b055e5d506