### PR TITLE
Add timing and perft optimization

### DIFF
--- a/examples/perft.cpp
+++ b/examples/perft.cpp
@@ -19,7 +19,8 @@ int main(int argc, char* argv[]) {
         depth = std::stoi(argv[2]);
     }
 
-    uint64_t nodes = perft(board, gen, depth);
-    std::cout << "Perft(" << depth << ") = " << nodes << "\n";
+    double ms = 0.0;
+    uint64_t nodes = perft(board, gen, depth, ms);
+    std::cout << "Perft(" << depth << ") = " << nodes << " in " << ms << " ms\n";
     return 0;
 }

--- a/src/MoveGeneratorUtils.cpp
+++ b/src/MoveGeneratorUtils.cpp
@@ -3,6 +3,19 @@
 #include "BitUtils.h"
 #include <iostream>
 #include <string>
+#include <array>
+
+namespace {
+const std::array<std::string, 64> algebraicSquares = [] {
+    std::array<std::string, 64> arr{};
+    for (int i = 0; i < 64; ++i) {
+        char file = 'a' + (i % 8);
+        char rank = '1' + (i / 8);
+        arr[i] = std::string{file} + rank;
+    }
+    return arr;
+}();
+} // namespace
 
 std::string squareToNotation(int square) {
     char file = 'a' + (square % 8);
@@ -11,9 +24,7 @@ std::string squareToNotation(int square) {
 }
 
 std::string indexToAlgebraic(int index) {
-    char file = 'a' + (index % 8);
-    int rank = (index / 8) + 1;
-    return std::string(1, file) + std::to_string(rank);
+    return algebraicSquares[index];
 }
 
 void printBitboard(uint64_t bitboard, const std::string& label) {

--- a/src/Perft.h
+++ b/src/Perft.h
@@ -4,3 +4,4 @@
 #include <cstdint>
 
 uint64_t perft(Board& board, MoveGenerator& generator, int depth);
+uint64_t perft(Board& board, MoveGenerator& generator, int depth, double& ms);


### PR DESCRIPTION
## Summary
- precompute algebraic notation strings
- rewrite perft to avoid board copies and add timed variant
- print timing in the perft example

## Testing
- `make PerftTest`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_688c1918bd18832ea2234917870470d7