### PR TITLE
Add regression test for engine move selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,12 @@ add_executable(IllegalMoveTests
     src/MoveGenerator.cpp
     src/PrintMoves.cpp ${ENGINE_SOURCES})
 
+add_executable(EngineMoveSelectionTest
+    test/EngineMoveSelectionTest.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 add_executable(GamePhaseTests
     test/GamePhaseTests.cpp
     src/Board.cpp
@@ -113,6 +119,7 @@ target_include_directories(KnightMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(IllegalMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(EngineMoveSelectionTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GamePhaseTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(DrawRuleTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(LegalMoveGenerationTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -135,6 +142,7 @@ add_test(NAME SliderMoveTests COMMAND SliderMoveTests)
 add_test(NAME KingMoveTests COMMAND KingMoveTests)
 add_test(NAME PerftTest COMMAND PerftTest)
 add_test(NAME IllegalMoveTests COMMAND IllegalMoveTests)
+add_test(NAME EngineMoveSelectionTest COMMAND EngineMoveSelectionTest)
 add_test(NAME GamePhaseTests COMMAND GamePhaseTests)
 add_test(NAME DrawRuleTests COMMAND DrawRuleTests)
 add_test(NAME LegalMoveGenerationTest COMMAND LegalMoveGenerationTest)

--- a/test/EngineMoveSelectionTest.cpp
+++ b/test/EngineMoveSelectionTest.cpp
@@ -1,0 +1,19 @@
+#include "Board.h"
+#include "Engine.h"
+#include <cassert>
+#include <iostream>
+
+void testNoIllegalKa3() {
+    Engine engine;
+    Board board;
+    board.loadFEN("5Q2/2p3p1/2p3p1/8/k4PRp/4r2P/1pP5/1K6 b - - 0 40");
+    std::string best = engine.searchBestMove(board, 2);
+    assert(best != "a4-a3");
+    std::cout << "Best move: " << best << "\n";
+}
+
+int main() {
+    testNoIllegalKa3();
+    std::cout << "\nEngine move selection test passed!\n";
+    return 0;
+}

--- a/test/IllegalMoveTests.cpp
+++ b/test/IllegalMoveTests.cpp
@@ -13,9 +13,29 @@ void testLegalMove() {
     assert(board.isMoveLegal("e2-e4"));
 }
 
+void testCheckDetection() {
+    Board board;
+    board.loadFEN("k3Q2r/p1p3p1/6p1/2p2b2/2pr1P1p/P3R2P/1PP2B2/2K3R1 b - - 0 33");
+    // Black is in check from the white queen on e8. Capturing on f4 does not resolve it.
+    assert(!board.isMoveLegal("d4-f4"));
+    // Capturing the checking queen is legal.
+    assert(board.isMoveLegal("h8-e8"));
+}
+
+void testKingIntoCheck() {
+    Board board;
+    board.loadFEN("5Q2/2p3p1/2p3p1/8/k4PRp/4r2P/1pP5/1K6 b - - 0 40");
+    // Moving the king to a3 would step into a queen attack.
+    assert(!board.isMoveLegal("a4-a3"));
+    // Capturing on h3 remains legal.
+    assert(board.isMoveLegal("e3-h3"));
+}
+
 int main() {
     testIllegalMove();
     testLegalMove();
+    testCheckDetection();
+    testKingIntoCheck();
     std::cout << "\nIllegal move tests passed!\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- add EngineMoveSelectionTest to ensure search avoids illegal Ka3 suggestion
- integrate new executable into CMake and CTest

## Testing
- `make EngineMoveSelectionTest`
- `./EngineMoveSelectionTest`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688c21b5dc24832eadf6a6ef7137ab1e