### PR TITLE
Add checkmate detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,12 @@ add_executable(StalemateTest
     src/MoveGenerator.cpp
     src/PrintMoves.cpp ${ENGINE_SOURCES})
 
+add_executable(CheckmateTest
+    test/CheckmateTest.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 add_executable(PerftTest
     test/PerftTest.cpp
     src/Board.cpp
@@ -124,6 +130,7 @@ target_include_directories(GamePhaseTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(DrawRuleTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(LegalMoveGenerationTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(StalemateTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(CheckmateTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(CreatePosition PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GenerateMoves PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -147,6 +154,7 @@ add_test(NAME GamePhaseTests COMMAND GamePhaseTests)
 add_test(NAME DrawRuleTests COMMAND DrawRuleTests)
 add_test(NAME LegalMoveGenerationTest COMMAND LegalMoveGenerationTest)
 add_test(NAME StalemateTest COMMAND StalemateTest)
+add_test(NAME CheckmateTest COMMAND CheckmateTest)
 add_test(NAME MVVLVAArrayTest COMMAND MVVLVAArrayTest)
 
 

--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -397,3 +397,11 @@ bool Board::isStalemate() const {
     auto moves = gen.generateLegalMoves(*this, whiteToMove);
     return moves.empty();
 }
+
+bool Board::isCheckmate() const {
+    MoveGenerator gen;
+    if (!gen.isKingInCheck(*this, whiteToMove))
+        return false;
+    auto moves = gen.generateLegalMoves(*this, whiteToMove);
+    return moves.empty();
+}

--- a/src/Board.h
+++ b/src/Board.h
@@ -67,6 +67,7 @@ public:
     bool isThreefoldRepetition() const;
     int repetitionCount() const;
     bool isStalemate() const;
+    bool isCheckmate() const;
 
     // Setters for testing
     void setWhitePawns(uint64_t value) { whitePawns = value; }

--- a/test/CheckmateTest.cpp
+++ b/test/CheckmateTest.cpp
@@ -1,0 +1,16 @@
+#include "Board.h"
+#include <cassert>
+#include <iostream>
+
+void testCheckmate() {
+    Board b;
+    b.loadFEN("7k/6Q1/7K/8/8/8/8/8 b - - 0 1");
+    assert(b.isCheckmate());
+    std::cout << "[✔] Checkmate detected\n";
+}
+
+int main() {
+    testCheckmate();
+    std::cout << "All tests done\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add Board::isCheckmate to detect checkmate positions
- create CheckmateTest and wire into CMake

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688cb6adb898832ea3fa403f8e1c367c