### PR TITLE
Add UCI option to adjust hash size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,10 @@ add_executable(PerftTest
 add_executable(MVVLVAArrayTest
     test/MVVLVAArrayTest.cpp)
 
+add_executable(TranspositionTableResizeTest
+    test/TranspositionTableResizeTest.cpp
+    src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 # Example programs
 add_executable(CreatePosition examples/create_position.cpp
     src/Board.cpp src/MoveGenerator.cpp src/PrintMoves.cpp ${ENGINE_SOURCES})
@@ -131,6 +135,7 @@ target_include_directories(Perft PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PerftTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(Aphelion PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(MVVLVAArrayTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(TranspositionTableResizeTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 target_link_libraries(Aphelion PRIVATE Threads::Threads)
 
@@ -148,6 +153,7 @@ add_test(NAME DrawRuleTests COMMAND DrawRuleTests)
 add_test(NAME LegalMoveGenerationTest COMMAND LegalMoveGenerationTest)
 add_test(NAME StalemateTest COMMAND StalemateTest)
 add_test(NAME MVVLVAArrayTest COMMAND MVVLVAArrayTest)
+add_test(NAME TranspositionTableResizeTest COMMAND TranspositionTableResizeTest)
 
 
 

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -31,6 +31,8 @@ public:
                                     std::atomic<bool>& stopFlag);
 
     void clearTranspositionTable() { tt.clear(); }
+    void setHashSizeMB(size_t mb);
+    size_t getHashSize() const { return tt.size(); }
 
 private:
     int quiescence(Board& board, int alpha, int beta, bool maximizing,

--- a/src/EngineSearch.cpp
+++ b/src/EngineSearch.cpp
@@ -455,3 +455,10 @@ std::string Engine::searchBestMoveTimed(Board& board, int maxDepth,
         return completedMove;
     return bestMove;
 }
+
+void Engine::setHashSizeMB(size_t mb) {
+    size_t bytes = mb * 1024 * 1024;
+    size_t entries = bytes / sizeof(TTSlot);
+    if (entries == 0) entries = 1;
+    tt.resize(entries);
+}

--- a/src/TranspositionTable.h
+++ b/src/TranspositionTable.h
@@ -21,6 +21,12 @@ public:
     explicit TranspositionTable(size_t size = DEFAULT_SIZE)
         : table(size), usedSlots(0) {}
 
+    void resize(size_t newSize) {
+        std::vector<TTSlot> newTable(newSize);
+        table.swap(newTable);
+        usedSlots.store(0, std::memory_order_relaxed);
+    }
+
     size_t size() const { return table.size(); }
 
     size_t used() const { return usedSlots.load(std::memory_order_relaxed); }

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -40,6 +40,19 @@ int main() {
             std::cout << "uciok" << '\n';
         } else if (line == "isready") {
             std::cout << "readyok" << '\n';
+        } else if (line.rfind("setoption", 0) == 0) {
+            auto namePos = line.find("name ");
+            auto valuePos = line.find(" value ");
+            if (namePos != std::string::npos) {
+                std::string name = line.substr(namePos + 5,
+                                              valuePos == std::string::npos ?
+                                              std::string::npos :
+                                              valuePos - (namePos + 5));
+                if (name == "Hash" && valuePos != std::string::npos) {
+                    int mb = std::stoi(line.substr(valuePos + 7));
+                    engine.setHashSizeMB(static_cast<size_t>(mb));
+                }
+            }
         } else if (line == "ucinewgame") {
             if (searchThread.joinable()) {
                 stopFlag = true;

--- a/test/TranspositionTableResizeTest.cpp
+++ b/test/TranspositionTableResizeTest.cpp
@@ -1,0 +1,14 @@
+#include "Engine.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    Engine engine;
+    size_t defaultSize = engine.getHashSize();
+    engine.setHashSizeMB(2); // 2 MB
+    size_t newSize = engine.getHashSize();
+    assert(newSize != defaultSize);
+    std::cout << "Hash table resized from " << defaultSize
+              << " to " << newSize << " entries\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow resizing the transposition table
- expose `setHashSizeMB` and `getHashSize` in the engine
- parse `setoption name Hash value <MB>` in the UCI interface
- add a small test exercising table resize

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688cb6adb898832ea3fa403f8e1c367c