### PR TITLE
Clear TT when updating position

### DIFF
--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -67,11 +67,13 @@ int main() {
             iss >> token;
             if (token == "startpos") {
                 board.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+                engine.clearTranspositionTable();
             } else if (token == "fen") {
                 std::string fenParts[6];
                 for (int i=0;i<6 && iss>>fenParts[i];++i) {}
                 std::string fen = fenParts[0]+" "+fenParts[1]+" "+fenParts[2]+" "+fenParts[3]+" "+fenParts[4]+" "+fenParts[5];
                 board.loadFEN(fen);
+                engine.clearTranspositionTable();
             }
             if (iss >> token && token == "moves") {
                 while (iss >> token) {


### PR DESCRIPTION
## Summary
- clear the transposition table whenever a new `position` command sets up a board

## Testing
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688d0b26e8a0832eb0f747fe73b1647a