### PR TITLE
Add negamax alpha-beta search

### DIFF
--- a/src/Engine.h
+++ b/src/Engine.h
@@ -24,6 +24,12 @@ public:
             const std::chrono::steady_clock::time_point& end,
             const std::atomic<bool>& stop);
 
+    // Simple negamax search with alpha-beta pruning
+    int negamaxAlphaBeta(Board& board, int depth,
+                         int alpha, int beta, int color,
+                         const std::chrono::steady_clock::time_point& end,
+                         const std::atomic<bool>& stop);
+
     std::string searchBestMove(Board& board, int depth);
 
     std::string searchBestMoveTimed(Board& board, int maxDepth,


### PR DESCRIPTION
## Summary
- implement a simple negamax search using alpha-beta pruning
- expose `negamaxAlphaBeta` in `Engine` API

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688d53a05a74832eb45969c8d31f6ace