### PR TITLE
Improve castling evaluation

### DIFF
--- a/src/EngineEvaluation.cpp
+++ b/src/EngineEvaluation.cpp
@@ -202,5 +202,24 @@ int Engine::evaluate(const Board& b) const {
     blackDevelop += countDeveloped(b.getBlackBishops(), {58,61});
     score += developBonus * (whiteDevelop - blackDevelop);
 
+    if (phase != GamePhase::Endgame) {
+        bool whiteCastled = (b.getWhiteKing() == (1ULL<<6)) ||
+                            (b.getWhiteKing() == (1ULL<<2));
+        bool blackCastled = (b.getBlackKing() == (1ULL<<62)) ||
+                            (b.getBlackKing() == (1ULL<<58));
+        bool whiteHome = b.getWhiteKing() == (1ULL<<4);
+        bool blackHome = b.getBlackKing() == (1ULL<<60);
+        int castleBonus = 40;
+        int stuckPenalty = 20;
+        if (whiteCastled)
+            score += castleBonus;
+        else if (whiteHome && !b.canCastleWK() && !b.canCastleWQ())
+            score -= stuckPenalty;
+        if (blackCastled)
+            score -= castleBonus;
+        else if (blackHome && !b.canCastleBK() && !b.canCastleBQ())
+            score += stuckPenalty;
+    }
+
     return score;
 }


### PR DESCRIPTION
## Summary
- reward castled kings and penalize unsafe king positions in early/mid game

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688d598bb534832e894bed1289c44bac