### PR TITLE
Allow UCI stop to interrupt search

### DIFF
--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -119,15 +119,14 @@ int main() {
 
             stopFlag = false;
             pondering = ponder;
-            searchThread = std::thread([&]() {
+            bool autoPrint = !infinite && !ponder;
+            searchThread = std::thread([&, autoPrint]() {
                 bestMove = engine.searchBestMoveTimed(board, depth, timeLimit, stopFlag);
+                if (autoPrint && !stopFlag) {
+                    std::string uci = bestMove.empty() ? "0000" : toUCIMove(bestMove);
+                    std::cout << "bestmove " << uci << '\n';
+                }
             });
-
-            if (!infinite && !ponder) {
-                searchThread.join();
-                std::string uci = bestMove.empty() ? "0000" : toUCIMove(bestMove);
-                std::cout << "bestmove " << uci << '\n';
-            }
         } else if (line == "ponderhit") {
             if (searchThread.joinable() && pondering) {
                 stopFlag = true;


### PR DESCRIPTION
## Summary
- avoid blocking the UCI loop when searching
- print best move from the search thread when search finishes normally

## Testing
- `ctest -j2`

------
https://chatgpt.com/codex/tasks/task_e_688e1b6535f0832ebad89427be8bf82e