### PR TITLE
Fix en passant capture masking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,12 @@ add_executable(IllegalMoveTests
     src/MoveGenerator.cpp
     src/PrintMoves.cpp ${ENGINE_SOURCES})
 
+add_executable(EnPassantRightCaptureTest
+    test/EnPassantRightCaptureTest.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/PrintMoves.cpp ${ENGINE_SOURCES})
+
 add_executable(EngineMoveSelectionTest
     test/EngineMoveSelectionTest.cpp
     src/Board.cpp
@@ -141,6 +147,7 @@ target_include_directories(KnightMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(SliderMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(KingMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(IllegalMoveTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(EnPassantRightCaptureTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(EngineMoveSelectionTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(GamePhaseTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(DrawRuleTests PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -169,6 +176,7 @@ add_test(NAME SliderMoveTests COMMAND SliderMoveTests)
 add_test(NAME KingMoveTests COMMAND KingMoveTests)
 add_test(NAME PerftTest COMMAND PerftTest)
 add_test(NAME IllegalMoveTests COMMAND IllegalMoveTests)
+add_test(NAME EnPassantRightCaptureTest COMMAND EnPassantRightCaptureTest)
 add_test(NAME EngineMoveSelectionTest COMMAND EngineMoveSelectionTest)
 add_test(NAME GamePhaseTests COMMAND GamePhaseTests)
 add_test(NAME DrawRuleTests COMMAND DrawRuleTests)

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -168,8 +168,10 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
       fromMask = ((epSquare >> 9) & pawns & 0xFEFEFEFEFEFEFEFEULL) |
                  ((epSquare >> 7) & pawns & 0x7F7F7F7F7F7F7F7FULL);
     } else {
-      fromMask = ((epSquare << 7) & pawns & 0xFEFEFEFEFEFEFEFEULL) |
-                 ((epSquare << 9) & pawns & 0x7F7F7F7F7F7F7F7FULL);
+      // Mirror the masks used for white so file wrapping is handled correctly
+      // for black pawns capturing en passant from either side.
+      fromMask = ((epSquare << 7) & pawns & 0x7F7F7F7F7F7F7F7FULL) |
+                 ((epSquare << 9) & pawns & 0xFEFEFEFEFEFEFEFEULL);
     }
 
     for (uint64_t mask = fromMask; mask; mask &= mask - 1) {

--- a/test/EnPassantRightCaptureTest.cpp
+++ b/test/EnPassantRightCaptureTest.cpp
@@ -1,0 +1,13 @@
+#include "Board.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    Board board;
+    board.loadFEN("r1b1rnk1/pp2bpp1/8/4NP1n/4p1Pp/P3B2P/1PP1P3/2KR1B1R b - g3 0 18");
+    assert(board.isMoveLegal("h4-g3"));
+    board.makeMove("h4-g3");
+    std::cout << "En passant capture executed.\n";
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- fix masking for black en passant capture generation so edge pawns are considered
- add regression test covering hxg3 en passant capture

## Testing
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_688e94514b5c832e82952f6d9ccd7d9d