### PR TITLE
Fix polyglot castling move conversion to UCI

### DIFF
--- a/src/OpeningBook.cpp
+++ b/src/OpeningBook.cpp
@@ -95,13 +95,22 @@ std::string OpeningBook::decodeMove(uint16_t mv) {
     int to = mv & 0x3f;
     int from = (mv >> 6) & 0x3f;
     int promo = (mv >> 12) & 0x7;
-    std::string s = indexToAlgebraic(from) + "-" + indexToAlgebraic(to);
+
+    // Polyglot represents castling moves using the king's origin square
+    // and the rook's destination square. Convert these to the standard
+    // UCI king destination squares.
+    if (from == 4 && to == 7)       to = 6;  // white short  e1h1 -> e1g1
+    else if (from == 4 && to == 0)  to = 2;  // white long   e1a1 -> e1c1
+    else if (from == 60 && to == 63) to = 62; // black short  e8h8 -> e8g8
+    else if (from == 60 && to == 56) to = 58; // black long   e8a8 -> e8c8
+
+    std::string s = indexToAlgebraic(from) + indexToAlgebraic(to);
     if (promo) {
         char p = 'q';
-        if (promo==1) p='n';
-        else if (promo==2) p='b';
-        else if (promo==3) p='r';
-        else if (promo==4) p='q';
+        if (promo == 1) p = 'n';
+        else if (promo == 2) p = 'b';
+        else if (promo == 3) p = 'r';
+        else if (promo == 4) p = 'q';
         s += p;
     }
     return s;

--- a/test/OpeningBookPolyglotTest.cpp
+++ b/test/OpeningBookPolyglotTest.cpp
@@ -37,8 +37,20 @@ void testPolyglotKeys() {
     std::cout << "[✔] Polyglot hash vectors validated\n";
 }
 
+void testPolyglotCastlingDecode() {
+    // White short castle: e1h1 -> e1g1
+    assert(OpeningBook::decodeMove(0x0107) == "e1g1");
+    // White long castle: e1a1 -> e1c1
+    assert(OpeningBook::decodeMove(0x0100) == "e1c1");
+    // Black short castle: e8h8 -> e8g8
+    assert(OpeningBook::decodeMove(0x0F3F) == "e8g8");
+    // Black long castle: e8a8 -> e8c8
+    assert(OpeningBook::decodeMove(0x0F38) == "e8c8");
+}
+
 int main() {
     testPolyglotKeys();
+    testPolyglotCastlingDecode();
     std::cout << "All opening book tests passed\n";
     return 0;
 }


### PR DESCRIPTION
## Summary
- convert polyglot castling encodings to standard UCI king moves
- add tests for castling move decoding

## Testing
- `ctest -R OpeningBookPolyglotTest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688ec5280544832e9a45b0b8706f658f