### PR TITLE
Add OwnBook UCI option

### DIFF
--- a/src/Engine.h
+++ b/src/Engine.h
@@ -39,6 +39,8 @@ public:
     void clearTranspositionTable() { tt.clear(); }
     void setHashSizeMB(size_t mb);
     size_t getHashSize() const { return tt.size(); }
+    void setOwnBook(bool enabled) { useOwnBook = enabled; }
+    bool isOwnBookEnabled() const { return useOwnBook; }
 
 private:
     int quiescence(Board& board, int alpha, int beta, bool maximizing,
@@ -50,4 +52,5 @@ private:
     OpeningBook book;
     Tablebase tablebase;
     ThreadPool pool;
+    bool useOwnBook = false;
 };

--- a/src/EngineSearch.cpp
+++ b/src/EngineSearch.cpp
@@ -422,8 +422,10 @@ std::pair<int, std::string> Engine::minimax(
 std::string Engine::searchBestMove(Board& board, int depth) {
     if (auto tb = tablebase.lookupMove(board))
         return *tb;
-    if (auto bm = book.getBookMove(board))
-        return *bm;
+    if (useOwnBook) {
+        if (auto bm = book.getBookMove(board))
+            return *bm;
+    }
 
     std::atomic<bool> dummyStop(false);
     std::string bestMove;
@@ -490,8 +492,10 @@ std::string Engine::searchBestMoveTimed(Board& board, int maxDepth,
 
     if (auto tb = tablebase.lookupMove(board))
         return *tb;
-    if (auto bm = book.getBookMove(board))
-        return *bm;
+    if (useOwnBook) {
+        if (auto bm = book.getBookMove(board))
+            return *bm;
+    }
 
     std::string bestMove;
     std::string bestPV;

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -53,6 +53,7 @@ int main() {
         if (line == "uci") {
             std::cout << "id name Aphelion 0.1" << '\n';
             std::cout << "id author Matt LaDuke and ChatGPT" << '\n';
+            std::cout << "option name OwnBook type check default false" << '\n';
             std::cout << "uciok" << '\n';
         } else if (line == "isready") {
             std::cout << "readyok" << '\n';
@@ -67,6 +68,11 @@ int main() {
                 if (name == "Hash" && valuePos != std::string::npos) {
                     int mb = std::stoi(line.substr(valuePos + 7));
                     engine.setHashSizeMB(static_cast<size_t>(mb));
+                } else if (name == "OwnBook" && valuePos != std::string::npos) {
+                    std::string val = line.substr(valuePos + 7);
+                    for (auto &c : val) c = static_cast<char>(std::tolower(c));
+                    bool enable = (val == "true" || val == "1");
+                    engine.setOwnBook(enable);
                 }
             }
         } else if (line == "ucinewgame") {


### PR DESCRIPTION
## Summary
- add `OwnBook` UCI option (check type, default false)
- allow enabling/disabling opening book usage in engine

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688ed2e5c9dc832eb0df236c504275a9