### PR TITLE
Add perft suite helper program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,12 @@ add_executable(PerftTest
     src/MoveGenerator.cpp
     src/Perft.cpp ${ENGINE_SOURCES})
 
+add_executable(PerftSuiteTest
+    test/PerftSuiteTest.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/Perft.cpp ${ENGINE_SOURCES})
+
 add_executable(MVVLVAArrayTest
     test/MVVLVAArrayTest.cpp)
 
@@ -170,6 +176,7 @@ target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(Perft PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PrintBook PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PerftTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(PerftSuiteTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(Aphelion PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(MVVLVAArrayTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(TranspositionTableResizeTest PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/test/PerftSuiteTest.cpp
+++ b/test/PerftSuiteTest.cpp
@@ -1,0 +1,94 @@
+#include "Perft.h"
+#include "Board.h"
+#include "MoveGenerator.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+void trim(std::string &s) {
+  size_t start = s.find_first_not_of(" \t\r\n");
+  size_t end = s.find_last_not_of(" \t\r\n");
+  if (start == std::string::npos) {
+    s.clear();
+  } else {
+    s = s.substr(start, end - start + 1);
+  }
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  int maxPositions = 126;
+  if (argc > 1) {
+    maxPositions = std::stoi(argv[1]);
+  }
+
+  namespace fs = std::filesystem;
+  fs::path filePath = fs::path(__FILE__).parent_path() / "perftsuite.epd";
+  std::ifstream file(filePath);
+  if (!file) {
+    std::cerr << "Failed to open " << filePath << std::endl;
+    return 1;
+  }
+
+  Board board;
+  MoveGenerator generator;
+  std::string line;
+  int index = 0;
+
+  while (index < maxPositions && std::getline(file, line)) {
+    trim(line);
+    if (line.empty()) continue;
+    ++index;
+
+    std::vector<std::string> parts;
+    std::stringstream ss(line);
+    std::string part;
+    while (std::getline(ss, part, ';')) {
+      trim(part);
+      if (!part.empty()) parts.push_back(part);
+    }
+    if (parts.empty()) continue;
+
+    std::string fen = parts[0];
+    if (!board.loadFEN(fen)) {
+      std::cerr << "Failed to load FEN for position " << index << std::endl;
+      return 1;
+    }
+
+    std::vector<uint64_t> expected(7, 0ULL);
+    for (size_t i = 1; i < parts.size(); ++i) {
+      std::stringstream ps(parts[i]);
+      std::string depthToken;
+      uint64_t nodes;
+      if (!(ps >> depthToken >> nodes)) continue;
+      if (depthToken.size() > 1 && depthToken[0] == 'D') {
+        int depth = std::stoi(depthToken.substr(1));
+        if (depth >= 1 && depth <= 6) {
+          expected[depth] = nodes;
+        }
+      }
+    }
+
+    for (int depth = 1; depth <= 6; ++depth) {
+      if (expected[depth] == 0) continue;
+      uint64_t nodes = perft(board, generator, depth);
+      if (nodes != expected[depth]) {
+        std::cerr << "Mismatch at position " << index << ", depth " << depth
+                  << ": expected " << expected[depth] << ", got " << nodes
+                  << std::endl;
+        return 1;
+      }
+    }
+  }
+
+  std::cout << "Tested " << index << " positions successfully." << std::endl;
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- add helper program to validate perft numbers from `test/perftsuite.epd`
- wire helper into build system for optional use

## Testing
- `ctest -j4 --test-dir build --output-on-failure`
- `build/PerftSuiteTest 1` *(reports mismatch at depth 5: expected 4865609, got 4865573)*

------
https://chatgpt.com/codex/tasks/task_e_689369b5730c832ebd69246c1cc8f681