### PR TITLE
Add per-move perft breakdown

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,12 @@ add_executable(PerftTest
     src/MoveGenerator.cpp
     src/Perft.cpp ${ENGINE_SOURCES})
 
+add_executable(PerftDivideTest
+    test/PerftDivideTest.cpp
+    src/Board.cpp
+    src/MoveGenerator.cpp
+    src/Perft.cpp ${ENGINE_SOURCES})
+
 add_executable(PerftSuiteTest
     test/PerftSuiteTest.cpp
     src/Board.cpp
@@ -176,6 +182,7 @@ target_include_directories(SearchBestMove PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(Perft PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PrintBook PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PerftTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(PerftDivideTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(PerftSuiteTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(Aphelion PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(MVVLVAArrayTest PRIVATE ${CMAKE_SOURCE_DIR}/src)
@@ -195,6 +202,7 @@ add_test(NAME KnightMoveTests COMMAND KnightMoveTests)
 add_test(NAME SliderMoveTests COMMAND SliderMoveTests)
 add_test(NAME KingMoveTests COMMAND KingMoveTests)
 add_test(NAME PerftTest COMMAND PerftTest)
+add_test(NAME PerftDivideTest COMMAND PerftDivideTest)
 add_test(NAME IllegalMoveTests COMMAND IllegalMoveTests)
 add_test(NAME EnPassantRightCaptureTest COMMAND EnPassantRightCaptureTest)
 add_test(NAME EngineMoveSelectionTest COMMAND EngineMoveSelectionTest)

--- a/examples/perft.cpp
+++ b/examples/perft.cpp
@@ -19,8 +19,13 @@ int main(int argc, char* argv[]) {
         depth = std::stoi(argv[2]);
     }
 
-    double ms = 0.0;
-    uint64_t nodes = perft(board, gen, depth, ms);
-    std::cout << "Perft(" << depth << ") = " << nodes << " in " << ms << " ms\n";
+    if (argc > 3 && std::string(argv[3]) == "divide") {
+        uint64_t nodes = perftDivide(board, gen, depth);
+        std::cout << "Perft divide total = " << nodes << "\n";
+    } else {
+        double ms = 0.0;
+        uint64_t nodes = perft(board, gen, depth, ms);
+        std::cout << "Perft(" << depth << ") = " << nodes << " in " << ms << " ms\n";
+    }
     return 0;
 }

--- a/src/Perft.cpp
+++ b/src/Perft.cpp
@@ -1,5 +1,6 @@
 #include "Perft.h"
 #include <chrono>
+#include <iostream>
 
 uint64_t perft(Board& board, MoveGenerator& generator, int depth) {
     if (depth == 0) return 1ULL;
@@ -35,4 +36,23 @@ uint64_t perft(Board& board, MoveGenerator& generator, int depth, double& ms) {
     auto end = std::chrono::steady_clock::now();
     ms = std::chrono::duration<double, std::milli>(end - start).count();
     return nodes;
+}
+
+uint64_t perftDivide(Board& board, MoveGenerator& generator, int depth) {
+    auto moves = generator.generateAllMoves(board, board.isWhiteToMove());
+    uint64_t total = 0ULL;
+
+    for (const auto& m : moves) {
+        Board::MoveState st;
+        board.makeMove(m, st);
+        uint64_t nodes = 0ULL;
+        if (!generator.isKingInCheck(board, !board.isWhiteToMove())) {
+            nodes = perft(board, generator, depth - 1);
+            total += nodes;
+            std::cout << m << ": " << nodes << "\n";
+        }
+        board.unmakeMove(st);
+    }
+
+    return total;
 }

--- a/src/Perft.h
+++ b/src/Perft.h
@@ -5,3 +5,4 @@
 
 uint64_t perft(Board& board, MoveGenerator& generator, int depth);
 uint64_t perft(Board& board, MoveGenerator& generator, int depth, double& ms);
+uint64_t perftDivide(Board& board, MoveGenerator& generator, int depth);

--- a/test/PerftDivideTest.cpp
+++ b/test/PerftDivideTest.cpp
@@ -1,0 +1,18 @@
+#include "Perft.h"
+#include "Board.h"
+#include "MoveGenerator.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    Board board;
+    MoveGenerator gen;
+    bool loaded = board.loadFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    assert(loaded);
+
+    uint64_t total = perft(board, gen, 2);
+    uint64_t divided = perftDivide(board, gen, 2);
+    assert(total == divided);
+    std::cout << "Perft divide total = " << divided << "\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose `perftDivide` utility to print node counts per first move
- extend perft example to optionally show per-move breakdown
- test perftDivide totals against standard perft

## Testing
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68936f047c34832ea4e1c2f031ade272