### PR TITLE
Fix en passant move generation on edge files

### DIFF
--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -165,8 +165,8 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
     uint64_t epSquare = 1ULL << board.getEnPassantSquare();
     uint64_t fromMask;
     if (isWhite) {
-      fromMask = ((epSquare >> 9) & pawns & 0xFEFEFEFEFEFEFEFEULL) |
-                 ((epSquare >> 7) & pawns & 0x7F7F7F7F7F7F7F7FULL);
+      fromMask = ((epSquare >> 9) & pawns & 0x7F7F7F7F7F7F7F7FULL) |
+                 ((epSquare >> 7) & pawns & 0xFEFEFEFEFEFEFEFEULL);
     } else {
       // Mirror the masks used for white so file wrapping is handled correctly
       // for black pawns capturing en passant from either side.

--- a/test/PerftTest.cpp
+++ b/test/PerftTest.cpp
@@ -24,8 +24,21 @@ void testInitialPerft() {
   assert(n3 == 8902);
 }
 
+void testEnPassantPerft() {
+  Board board;
+  MoveGenerator gen;
+  bool loaded = board.loadFEN(
+      "rnbqkbnr/2pppppp/p7/Pp6/8/8/1PPPPPPP/RNBQKBNR w KQkq b6 0 3");
+  assert(loaded);
+
+  uint64_t n1 = perft(board, gen, 1);
+  std::cout << "En passant Perft(1) = " << n1 << std::endl;
+  assert(n1 == 22);
+}
+
 int main() {
   testInitialPerft();
+  testEnPassantPerft();
   std::cout << "\nPerft tests passed!" << std::endl;
   return 0;
 }


### PR DESCRIPTION
## Summary
- correct white pawn en passant masks to allow captures from the A-file
- add perft test for en passant capture from FEN `rnbqkbnr/2pppppp/p7/Pp6/8/8/1PPPPPPP/RNBQKBNR w KQkq b6 0 3`

## Testing
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68940df535f8832e8e9434865fafd4f0