### PR TITLE
Unify move encoding across move generation

### DIFF
--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -1,5 +1,6 @@
 #include "Board.h"
 #include "MoveGenerator.h"
+#include "MoveEncoding.h"
 #include "Zobrist.h"
 #include <iostream>
 #include <sstream>
@@ -196,8 +197,9 @@ bool Board::isMoveLegal(const std::string& move) const {
     MoveGenerator gen;
     auto moves = gen.generateAllMoves(*this, whiteToMove);
     std::string check = move.substr(0,5);
-    for (const auto& m : moves) {
-        if (m.substr(0,5) == check) {
+    for (auto m : moves) {
+        std::string decoded = decodeMove(m);
+        if (decoded.substr(0,5) == check) {
             Board copy = *this;
             copy.applyMove(move);
             return !gen.isKingInCheck(copy, !copy.isWhiteToMove());

--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -2,6 +2,7 @@
 #include "BitUtils.h"
 #include "Board.h"
 #include "Magic.h"
+#include "MoveEncoding.h"
 #include <vector>
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -49,9 +50,9 @@ MoveGenerator::MoveGenerator() {
   initLeaperTables();
 }
 
-std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
-                                                          bool isWhite) const {
-  std::vector<std::string> moves;
+std::vector<uint16_t> MoveGenerator::generatePawnMoves(const Board &board,
+                                                       bool isWhite) const {
+  std::vector<uint16_t> moves;
   uint64_t pawns = isWhite ? board.getWhitePawns() : board.getBlackPawns();
   uint64_t ownPieces =
       isWhite ? board.getWhitePieces() : board.getBlackPieces();
@@ -72,9 +73,9 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
       int from = to - 8;
       if ((1ULL << to) & whitePromRank) {
         for (char p : {'q', 'r', 'b', 'n'})
-          moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p);
+          moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p));
       } else {
-        moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
       }
     }
 
@@ -84,7 +85,7 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
     for (uint64_t targets = two; targets; targets &= targets - 1) {
       int to = lsbIndex(targets);
       int from = to - 16;
-      moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+      moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
     }
 
     // Captures
@@ -94,9 +95,9 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
       int from = to - 9;
       if ((1ULL << to) & whitePromRank) {
         for (char p : {'q', 'r', 'b', 'n'})
-          moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p);
+          moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p));
       } else {
-        moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
       }
     }
 
@@ -106,9 +107,9 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
       int from = to - 7;
       if ((1ULL << to) & whitePromRank) {
         for (char p : {'q', 'r', 'b', 'n'})
-          moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p);
+          moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p));
       } else {
-        moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
       }
     }
   } else {
@@ -119,9 +120,9 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
       int from = to + 8;
       if ((1ULL << to) & blackPromRank) {
         for (char p : {'q', 'r', 'b', 'n'})
-          moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p);
+          moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p));
       } else {
-        moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
       }
     }
 
@@ -131,7 +132,7 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
     for (uint64_t targets = two; targets; targets &= targets - 1) {
       int to = lsbIndex(targets);
       int from = to + 16;
-      moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+      moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
     }
 
     // Captures
@@ -141,9 +142,9 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
       int from = to + 7;
       if ((1ULL << to) & blackPromRank) {
         for (char p : {'q', 'r', 'b', 'n'})
-          moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p);
+          moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p));
       } else {
-        moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
       }
     }
 
@@ -153,9 +154,9 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
       int from = to + 9;
       if ((1ULL << to) & blackPromRank) {
         for (char p : {'q', 'r', 'b', 'n'})
-          moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p);
+          moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to) + p));
       } else {
-        moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+        moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
       }
     }
   }
@@ -177,25 +178,25 @@ std::vector<std::string> MoveGenerator::generatePawnMoves(const Board &board,
     for (uint64_t mask = fromMask; mask; mask &= mask - 1) {
       int from = lsbIndex(mask);
       int to = board.getEnPassantSquare();
-      moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+      moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
     }
   }
 
   return moves;
 }
 
-void MoveGenerator::addMoves(std::vector<std::string> &moves, uint64_t pawns,
+void MoveGenerator::addMoves(std::vector<uint16_t> &moves, uint64_t pawns,
                              uint64_t moveBoard, int shift) const {
   for (int from = 0; moveBoard; moveBoard &= moveBoard - 1) {
     int to = lsbIndex(moveBoard);
     from = to - shift; // Calculate starting square
-    moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+    moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
   }
 }
 
-std::vector<std::string>
+std::vector<uint16_t>
 MoveGenerator::generateKnightMoves(const Board &board, bool isWhite) const {
-  std::vector<std::string> moves;
+  std::vector<uint16_t> moves;
   uint64_t knights =
       isWhite ? board.getWhiteKnights() : board.getBlackKnights();
   uint64_t ownPieces =
@@ -205,16 +206,16 @@ MoveGenerator::generateKnightMoves(const Board &board, bool isWhite) const {
     uint64_t attacks = knightAttackTable[from] & ~ownPieces;
     for (uint64_t m = attacks; m; m &= m - 1) {
       int to = lsbIndex(m);
-      moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+      moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
     }
   }
 
   return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateRookMoves(const Board &board,
-                                                          bool isWhite) const {
-  std::vector<std::string> moves;
+std::vector<uint16_t> MoveGenerator::generateRookMoves(const Board &board,
+                                                       bool isWhite) const {
+  std::vector<uint16_t> moves;
   uint64_t rooks = isWhite ? board.getWhiteRooks() : board.getBlackRooks();
   uint64_t ownPieces =
       isWhite ? board.getWhitePieces() : board.getBlackPieces();
@@ -224,15 +225,15 @@ std::vector<std::string> MoveGenerator::generateRookMoves(const Board &board,
     uint64_t attacks = Magic::getRookAttacks(from, occupancy) & ~ownPieces;
     for (uint64_t m = attacks; m; m &= m - 1) {
       int to = lsbIndex(m);
-      moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+      moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
     }
   }
   return moves;
 }
 
-std::vector<std::string>
+std::vector<uint16_t>
 MoveGenerator::generateBishopMoves(const Board &board, bool isWhite) const {
-  std::vector<std::string> moves;
+  std::vector<uint16_t> moves;
   uint64_t bishops =
       isWhite ? board.getWhiteBishops() : board.getBlackBishops();
   uint64_t ownPieces =
@@ -243,15 +244,15 @@ MoveGenerator::generateBishopMoves(const Board &board, bool isWhite) const {
     uint64_t attacks = Magic::getBishopAttacks(from, occupancy) & ~ownPieces;
     for (uint64_t m = attacks; m; m &= m - 1) {
       int to = lsbIndex(m);
-      moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+      moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
     }
   }
   return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateQueenMoves(const Board &board,
-                                                           bool isWhite) const {
-  std::vector<std::string> moves;
+std::vector<uint16_t> MoveGenerator::generateQueenMoves(const Board &board,
+                                                        bool isWhite) const {
+  std::vector<uint16_t> moves;
   uint64_t queens = isWhite ? board.getWhiteQueens() : board.getBlackQueens();
   uint64_t ownPieces =
       isWhite ? board.getWhitePieces() : board.getBlackPieces();
@@ -263,15 +264,15 @@ std::vector<std::string> MoveGenerator::generateQueenMoves(const Board &board,
                        ~ownPieces;
     for (uint64_t m = attacks; m; m &= m - 1) {
       int to = lsbIndex(m);
-      moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+      moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
     }
   }
   return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateKingMoves(const Board &board,
-                                                          bool isWhite) const {
-  std::vector<std::string> moves;
+std::vector<uint16_t> MoveGenerator::generateKingMoves(const Board &board,
+                                                       bool isWhite) const {
+  std::vector<uint16_t> moves;
   uint64_t king = isWhite ? board.getWhiteKing() : board.getBlackKing();
   if (!king)
     return moves;
@@ -281,7 +282,7 @@ std::vector<std::string> MoveGenerator::generateKingMoves(const Board &board,
   uint64_t attacks = kingAttackTable[from] & ~ownPieces;
   for (uint64_t m = attacks; m; m &= m - 1) {
     int to = lsbIndex(m);
-    moves.push_back(indexToAlgebraic(from) + "-" + indexToAlgebraic(to));
+    moves.push_back(encodeMove(indexToAlgebraic(from) + "-" + indexToAlgebraic(to)));
   }
 
   uint64_t allPieces = board.getWhitePieces() | board.getBlackPieces();
@@ -291,14 +292,14 @@ std::vector<std::string> MoveGenerator::generateKingMoves(const Board &board,
         (board.getWhiteRooks() & (1ULL << 7)) && !isKingInCheck(board, true) &&
         !isSquareAttacked(board, 5, false) &&
         !isSquareAttacked(board, 6, false)) {
-      moves.push_back("e1-g1 (Castle Kingside)");
+      moves.push_back(encodeMove("e1-g1"));
     }
     if (board.canCastleWQ() && (from == 4) &&
         !(allPieces & ((1ULL << 1) | (1ULL << 2) | (1ULL << 3))) &&
         (board.getWhiteRooks() & (1ULL << 0)) && !isKingInCheck(board, true) &&
         !isSquareAttacked(board, 3, false) &&
         !isSquareAttacked(board, 2, false)) {
-      moves.push_back("e1-c1 (Castle Queenside)");
+      moves.push_back(encodeMove("e1-c1"));
     }
   } else {
     if (board.canCastleBK() && (from == 60) &&
@@ -306,24 +307,24 @@ std::vector<std::string> MoveGenerator::generateKingMoves(const Board &board,
         (board.getBlackRooks() & (1ULL << 63)) &&
         !isKingInCheck(board, false) && !isSquareAttacked(board, 61, true) &&
         !isSquareAttacked(board, 62, true)) {
-      moves.push_back("e8-g8 (Castle Kingside)");
+      moves.push_back(encodeMove("e8-g8"));
     }
     if (board.canCastleBQ() && (from == 60) &&
         !(allPieces & ((1ULL << 57) | (1ULL << 58) | (1ULL << 59))) &&
         (board.getBlackRooks() & (1ULL << 56)) &&
         !isKingInCheck(board, false) && !isSquareAttacked(board, 59, true) &&
         !isSquareAttacked(board, 58, true)) {
-      moves.push_back("e8-c8 (Castle Queenside)");
+      moves.push_back(encodeMove("e8-c8"));
     }
   }
 
   return moves;
 }
 
-std::vector<std::string> MoveGenerator::generateAllMoves(const Board &board,
-                                                         bool isWhite) const {
-  std::vector<std::string> all;
-  auto append = [&all](const std::vector<std::string> &mv) {
+std::vector<uint16_t> MoveGenerator::generateAllMoves(const Board &board,
+                                                      bool isWhite) const {
+  std::vector<uint16_t> all;
+  auto append = [&all](const std::vector<uint16_t> &mv) {
     all.insert(all.end(), mv.begin(), mv.end());
   };
   append(generatePawnMoves(board, isWhite));
@@ -335,12 +336,12 @@ std::vector<std::string> MoveGenerator::generateAllMoves(const Board &board,
   return all;
 }
 
-std::vector<std::string> MoveGenerator::generateLegalMoves(const Board &board,
-                                                           bool isWhite) const {
+std::vector<uint16_t> MoveGenerator::generateLegalMoves(const Board &board,
+                                                        bool isWhite) const {
   auto pseudo = generateAllMoves(board, isWhite);
-  std::vector<std::string> legal;
-  for (const auto &mv : pseudo) {
-    if (board.isMoveLegal(mv))
+  std::vector<uint16_t> legal;
+  for (auto mv : pseudo) {
+    if (board.isMoveLegal(decodeMove(mv)))
       legal.push_back(mv);
   }
   return legal;

--- a/src/MoveGenerator.h
+++ b/src/MoveGenerator.h
@@ -10,15 +10,15 @@
 class MoveGenerator {
 public:
     MoveGenerator();
-    std::vector<std::string> generatePawnMoves(const Board& board, bool isWhite) const;
-    std::vector<std::string> generateKnightMoves(const Board& board, bool isWhite) const;
-    std::vector<std::string> generateRookMoves(const Board& board, bool isWhite) const;
-    std::vector<std::string> generateBishopMoves(const Board& board, bool isWhite) const;
-    std::vector<std::string> generateQueenMoves(const Board& board, bool isWhite) const;
-    std::vector<std::string> generateKingMoves(const Board& board, bool isWhite) const;
-    std::vector<std::string> generateAllMoves(const Board& board, bool isWhite) const;
-    std::vector<std::string> generateLegalMoves(const Board& board, bool isWhite) const;
-    void addMoves(std::vector<std::string>& moves, uint64_t pawns, uint64_t moveBoard, int shift) const;
+    std::vector<uint16_t> generatePawnMoves(const Board& board, bool isWhite) const;
+    std::vector<uint16_t> generateKnightMoves(const Board& board, bool isWhite) const;
+    std::vector<uint16_t> generateRookMoves(const Board& board, bool isWhite) const;
+    std::vector<uint16_t> generateBishopMoves(const Board& board, bool isWhite) const;
+    std::vector<uint16_t> generateQueenMoves(const Board& board, bool isWhite) const;
+    std::vector<uint16_t> generateKingMoves(const Board& board, bool isWhite) const;
+    std::vector<uint16_t> generateAllMoves(const Board& board, bool isWhite) const;
+    std::vector<uint16_t> generateLegalMoves(const Board& board, bool isWhite) const;
+    void addMoves(std::vector<uint16_t>& moves, uint64_t pawns, uint64_t moveBoard, int shift) const;
 
     bool isSquareAttacked(const Board& board, int square, bool byWhite) const;
     bool isKingInCheck(const Board& board, bool white) const;

--- a/src/Perft.cpp
+++ b/src/Perft.cpp
@@ -1,6 +1,7 @@
 #include "Perft.h"
 #include <chrono>
 #include <iostream>
+#include "MoveEncoding.h"
 
 uint64_t perft(Board& board, MoveGenerator& generator, int depth) {
     if (depth == 0) return 1ULL;
@@ -9,9 +10,10 @@ uint64_t perft(Board& board, MoveGenerator& generator, int depth) {
 
     if (depth == 1) {
         uint64_t count = 0ULL;
-        for (const auto& m : moves) {
+        for (auto m : moves) {
+            std::string sm = decodeMove(m);
             Board::MoveState st;
-            board.makeMove(m, st);
+            board.makeMove(sm, st);
             if (!generator.isKingInCheck(board, !board.isWhiteToMove()))
                 ++count;
             board.unmakeMove(st);
@@ -20,9 +22,10 @@ uint64_t perft(Board& board, MoveGenerator& generator, int depth) {
     }
 
     uint64_t nodes = 0ULL;
-    for (const auto& m : moves) {
+    for (auto m : moves) {
+        std::string sm = decodeMove(m);
         Board::MoveState st;
-        board.makeMove(m, st);
+        board.makeMove(sm, st);
         if (!generator.isKingInCheck(board, !board.isWhiteToMove()))
             nodes += perft(board, generator, depth - 1);
         board.unmakeMove(st);
@@ -42,14 +45,15 @@ uint64_t perftDivide(Board& board, MoveGenerator& generator, int depth) {
     auto moves = generator.generateAllMoves(board, board.isWhiteToMove());
     uint64_t total = 0ULL;
 
-    for (const auto& m : moves) {
+    for (auto m : moves) {
+        std::string sm = decodeMove(m);
         Board::MoveState st;
-        board.makeMove(m, st);
+        board.makeMove(sm, st);
         uint64_t nodes = 0ULL;
         if (!generator.isKingInCheck(board, !board.isWhiteToMove())) {
             nodes = perft(board, generator, depth - 1);
             total += nodes;
-            std::cout << m << ": " << nodes << "\n";
+            std::cout << sm << ": " << nodes << "\n";
         }
         board.unmakeMove(st);
     }

--- a/src/PrintMoves.cpp
+++ b/src/PrintMoves.cpp
@@ -3,12 +3,13 @@
 // -----------------------------------------------------------------------------
 #include <iostream>
 #include "PrintMoves.h"
+#include "MoveEncoding.h"
 
 // -----------------------------------------------------------------------------
 // Prints each move in the provided list on its own line.
 // -----------------------------------------------------------------------------
-void printMoves(const std::vector<std::string>& moves) {
-    for (const auto& move : moves) {
-        std::cout << "Move: " << move << "\n";
+void printMoves(const std::vector<uint16_t>& moves) {
+    for (auto move : moves) {
+        std::cout << "Move: " << decodeMove(move) << "\n";
     }
 }

--- a/src/PrintMoves.h
+++ b/src/PrintMoves.h
@@ -1,5 +1,5 @@
 #pragma once
 #include <vector>
-#include <string>
+#include <cstdint>
 
-void printMoves(const std::vector<std::string>& moves);
+void printMoves(const std::vector<uint16_t>& moves);

--- a/test/KnightMoveTests.cpp
+++ b/test/KnightMoveTests.cpp
@@ -10,7 +10,7 @@ void testCenterKnightMoves() {
     board.setWhiteKnights(1ULL << 27); // Knight on d4
 
     MoveGenerator gen;
-    std::vector<std::string> moves = gen.generateKnightMoves(board, true);
+    std::vector<uint16_t> moves = gen.generateKnightMoves(board, true);
     std::cout << "\n[?] Center Knight Moves\n";
     printMoves(moves);
     assert(moves.size() == 8);
@@ -22,7 +22,7 @@ void testCornerKnightMoves() {
     board.setWhiteKnights(1ULL << 0); // Knight on a1
 
     MoveGenerator gen;
-    std::vector<std::string> moves = gen.generateKnightMoves(board, true);
+    std::vector<uint16_t> moves = gen.generateKnightMoves(board, true);
     std::cout << "\n[?] Corner Knight Moves\n";
     printMoves(moves);
     assert(moves.size() == 2);

--- a/test/LegalMoveGenerationTest.cpp
+++ b/test/LegalMoveGenerationTest.cpp
@@ -1,6 +1,7 @@
 #include "Board.h"
 #include "MoveGenerator.h"
 #include "PrintMoves.h"
+#include "MoveEncoding.h"
 #include <cassert>
 #include <iostream>
 
@@ -18,16 +19,18 @@ void testPinnedRook() {
 
 
     bool hasIllegal = false;
-    for (const auto& m : pseudo) {
-        if (m.rfind("b1-", 0) == 0 && m != "b1-a1") {
+    for (auto m : pseudo) {
+        std::string s = decodeMove(m);
+        if (s.rfind("b1-", 0) == 0 && s != "b1-a1") {
             hasIllegal = true;
             break;
         }
     }
     assert(hasIllegal);
 
-    for (const auto& m : legal) {
-        if (m.rfind("b1-", 0) == 0 && m != "b1-a1") {
+    for (auto m : legal) {
+        std::string s = decodeMove(m);
+        if (s.rfind("b1-", 0) == 0 && s != "b1-a1") {
             assert(false && "illegal move returned by generateLegalMoves");
         }
     }

--- a/test/PawnMoveTests.cpp
+++ b/test/PawnMoveTests.cpp
@@ -2,6 +2,7 @@
 #include "MoveGenerator.h"
 #include "PrintMoves.h"
 #include "BitUtils.h"
+#include "MoveEncoding.h"
 #include <iostream>
 #include <cassert>
 
@@ -14,7 +15,7 @@ void testPawnPromotion() {
     board.setWhitePawns(0x00FF000000000000); // Pawns on Rank 7 (promotion row)
     MoveGenerator generator;
 
-    std::vector<std::string> moves = generator.generatePawnMoves(board, true);
+    std::vector<uint16_t> moves = generator.generatePawnMoves(board, true);
     std::cout << "\n[?] Pawn Promotion Test\n";
     printMoves(moves);
 
@@ -22,7 +23,7 @@ void testPawnPromotion() {
     assert(moves.size() == 32);
 
     // Apply one underpromotion and verify board state changes
-    board.makeMove(moves.front());
+    board.makeMove(decodeMove(moves.front()));
     // The moved piece should no longer be a pawn
     assert(popcount64(board.getWhitePawns()) == 7);
 }
@@ -43,7 +44,7 @@ void testEnPassant() {
     board.setEnPassantSquare(43);  // Position d6 in bitboard notation
 
     MoveGenerator generator;
-    std::vector<std::string> moves = generator.generatePawnMoves(board, true);
+    std::vector<uint16_t> moves = generator.generatePawnMoves(board, true);
 
     std::cout << "\n[?] En Passant Test\n";
     printMoves(moves);

--- a/test/SliderMoveTests.cpp
+++ b/test/SliderMoveTests.cpp
@@ -10,7 +10,7 @@ void testRookMoves() {
     board.setWhiteRooks(1ULL << 27); // d4
 
     MoveGenerator gen;
-    auto moves = gen.generateRookMoves(board, true);
+    std::vector<uint16_t> moves = gen.generateRookMoves(board, true);
     std::cout << "\n[?] Rook Moves\n";
     printMoves(moves);
     assert(moves.size() == 14);
@@ -22,7 +22,7 @@ void testBishopMoves() {
     board.setWhiteBishops(1ULL << 27); // d4
 
     MoveGenerator gen;
-    auto moves = gen.generateBishopMoves(board, true);
+    std::vector<uint16_t> moves = gen.generateBishopMoves(board, true);
     std::cout << "\n[?] Bishop Moves\n";
     printMoves(moves);
     assert(moves.size() == 13);
@@ -34,7 +34,7 @@ void testQueenMoves() {
     board.setWhiteQueens(1ULL << 27); // d4
 
     MoveGenerator gen;
-    auto moves = gen.generateQueenMoves(board, true);
+    std::vector<uint16_t> moves = gen.generateQueenMoves(board, true);
     std::cout << "\n[?] Queen Moves\n";
     printMoves(moves);
     assert(moves.size() == 27);


### PR DESCRIPTION
## Summary
- Represent moves as 16-bit encoded values across the move generator
- Decode encoded moves when printing, legality checking and search logic
- Update perft routines and tests to use the shared encoded format

## Testing
- `cmake --build . --target KnightMoveTests`
- `./KnightMoveTests`
- `cmake --build . --target PawnMoveTests`
- `./PawnMoveTests`


------
https://chatgpt.com/codex/tasks/task_e_689496b07e08832eb469e8ca0e2636ea