### PR TITLE
Adjust evaluation to be side-aware

### DIFF
--- a/src/EngineEvaluation.cpp
+++ b/src/EngineEvaluation.cpp
@@ -351,5 +351,8 @@ int Engine::evaluate(const Board &b) const {
       score += stuckPenalty;
   }
 
-  return score;
+  // Return the evaluation from the perspective of the side to move so that
+  // the score is symmetric regardless of whose turn it is. Positive values
+  // always mean the side to move is favored.
+  return b.isWhiteToMove() ? score : -score;
 }

--- a/src/EngineSearch.cpp
+++ b/src/EngineSearch.cpp
@@ -169,9 +169,9 @@ int Engine::quiescence(Board& board, int alpha, int beta, bool maximizing,
                        const std::chrono::steady_clock::time_point& end,
                        const std::atomic<bool>& stop) {
     if (stop || std::chrono::steady_clock::now() >= end)
-        return evaluate(board);
+        return (board.isWhiteToMove() ? 1 : -1) * evaluate(board);
     nodes++;
-    int standPat = evaluate(board);
+    int standPat = (board.isWhiteToMove() ? 1 : -1) * evaluate(board);
     if (maximizing) {
         if (standPat >= beta) return standPat;
         if (standPat > alpha) alpha = standPat;
@@ -268,7 +268,7 @@ std::pair<int, std::string> Engine::minimax(
                     historyTable[s][f][t] = 0;
     }
     if (stop || std::chrono::steady_clock::now() >= end)
-        return {evaluate(board), ""};
+        return {(board.isWhiteToMove() ? 1 : -1) * evaluate(board), ""};
     if (board.isFiftyMoveDraw() || board.isThreefoldRepetition())
         return {0, ""};
     uint64_t key = Zobrist::hashBoard(board);


### PR DESCRIPTION
## Summary
- Make evaluation return a score from the perspective of the side to move for symmetry
- Ensure quiescence and minimax use side-aware scores when terminating early

## Testing
- `cmake --build . --target PawnStructureEvaluationTest`
- `timeout 5s ./PawnStructureEvaluationTest`
- `cmake --build . --target PassedPawnEvaluationTest`
- `timeout 5s ./PassedPawnEvaluationTest`


------
https://chatgpt.com/codex/tasks/task_e_6894a20fd7fc832eb66df6f647ab7777