### PR TITLE
Avoid repeated leaper table init

### DIFF
--- a/src/MoveGenerator.cpp
+++ b/src/MoveGenerator.cpp
@@ -17,8 +17,11 @@
 namespace {
 std::array<uint64_t, 64> knightAttackTable{};
 std::array<uint64_t, 64> kingAttackTable{};
+bool leaperTablesInitialized = false;
 
 void initLeaperTables() {
+  if (leaperTablesInitialized)
+    return;
   const int knightOffsets[8][2] = {{1, 2},  {2, 1},  {-1, 2}, {-2, 1},
                                    {1, -2}, {2, -1}, {-1, -2}, {-2, -1}};
   for (int sq = 0; sq < 64; ++sq) {
@@ -42,6 +45,7 @@ void initLeaperTables() {
     knightAttackTable[sq] = nMoves;
     kingAttackTable[sq] = kMoves;
   }
+  leaperTablesInitialized = true;
 }
 } // namespace
 


### PR DESCRIPTION
## Summary
- Guard leaper table initialization so MoveGenerator builds attack tables only once

## Testing
- `ctest`


------
https://chatgpt.com/codex/tasks/task_e_6894b3f38f88832e8a21c42a0acec69f