### PR TITLE
Fix repetition table update during unmake

### DIFF
--- a/src/Board.cpp
+++ b/src/Board.cpp
@@ -242,16 +242,10 @@ void Board::makeMove(const std::string& move, MoveState& state) {
     state.fullmoveNumber = fullmoveNumber;
 
     applyMove(move);
+    state.zobristKey = Zobrist::hashBoard(*this);
 }
 
 void Board::unmakeMove(const MoveState& state) {
-    uint64_t key = Zobrist::hashBoard(*this);
-    auto it = repetitionTable.find(key);
-    if (it != repetitionTable.end()) {
-        if (--it->second == 0)
-            repetitionTable.erase(it);
-    }
-
     whitePawns = state.whitePawns;
     whiteKnights = state.whiteKnights;
     whiteBishops = state.whiteBishops;
@@ -272,6 +266,12 @@ void Board::unmakeMove(const MoveState& state) {
     castleBQ = state.castleBQ;
     halfmoveClock = state.halfmoveClock;
     fullmoveNumber = state.fullmoveNumber;
+
+    auto it = repetitionTable.find(state.zobristKey);
+    if (it != repetitionTable.end()) {
+        if (--it->second == 0)
+            repetitionTable.erase(it);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/src/Board.h
+++ b/src/Board.h
@@ -28,6 +28,7 @@ public:
         bool castleWK, castleWQ, castleBK, castleBQ;
         int halfmoveClock;
         int fullmoveNumber;
+        uint64_t zobristKey;  // Hash of the position after the move
     };
 
     enum class Color { None, White, Black };


### PR DESCRIPTION
## Summary
- store Zobrist hash of each move in `MoveState`
- update repetition table after board state is restored using the stored hash

## Testing
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_6894ba4bfda8832eb3e73ef41114a79c