### PR TITLE
Add knight, king, and queen attack helpers to Magic bitboards

### DIFF
--- a/src/Magic.h
+++ b/src/Magic.h
@@ -5,4 +5,7 @@ namespace Magic {
     void init();
     U64 getRookAttacks(int sq, U64 occ);
     U64 getBishopAttacks(int sq, U64 occ);
+    U64 getKnightAttacks(int sq);
+    U64 getKingAttacks(int sq);
+    U64 getQueenAttacks(int sq, U64 occ);
 }


### PR DESCRIPTION
## Summary
- extend `Magic` with precomputed attack tables for knights and kings
- add helper to combine bishop and rook magic for queen attacks

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_6894db0c7724832ebbef8a024d670071